### PR TITLE
Fix Stripe webhook purchase reconciliation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -30,6 +30,12 @@ import {
   readFalRequestConfig,
   resolveFalProfile as resolveConfiguredFalProfile,
 } from './lib/falRequest.js';
+import {
+  buildPurchasedTierUpdate,
+  buildPendingPurchaseUpdate,
+  normalizePaidTier,
+  resolveHigherPaidTier,
+} from './lib/payments.js';
 import { buildRateLimiter, createRateLimitStore } from './lib/rateLimit.js';
 import { registerAdminRoutes } from './routes/admin.js';
 import { registerBattleRoutes } from './routes/battle.js';
@@ -405,7 +411,9 @@ function pruneBoardImageJobs(now = Date.now()) {
 }
 
 async function syncPurchasedTier({ tier, email, sessionId }) {
-  if (!adminDb || !tier) return;
+  if (!adminDb) return;
+  const normalizedTier = normalizePaidTier(tier);
+  if (!normalizedTier) return;
   const normalizedEmail = normalizeEmail(email);
   if (!normalizedEmail) return;
   const exactEmail = getTrimmedString(email, 320);
@@ -424,17 +432,68 @@ async function syncPurchasedTier({ tier, email, sessionId }) {
       matchingDocs.set(docSnap.ref.path, docSnap);
     });
   });
-  if (matchingDocs.size === 0) return;
+  const batch = adminDb.batch();
+
+  if (matchingDocs.size === 0) {
+    const pendingPurchaseRef = adminDb.collection('stripePurchases').doc(normalizedEmail);
+    const pendingPurchaseSnap = await pendingPurchaseRef.get();
+    const pendingUpdate = buildPendingPurchaseUpdate(pendingPurchaseSnap.data(), {
+      emailLower: normalizedEmail,
+      tier: normalizedTier,
+      sessionId,
+    }, FieldValue.serverTimestamp());
+    if (pendingUpdate) {
+      batch.set(pendingPurchaseRef, pendingUpdate, { merge: true });
+    }
+    await batch.commit();
+    return;
+  }
+
+  matchingDocs.forEach((docSnap) => {
+    const nextData = buildPurchasedTierUpdate(docSnap.data(), {
+      tier: normalizedTier,
+      emailLower: normalizedEmail,
+      sessionId,
+    }, FieldValue.serverTimestamp());
+    if (!nextData) return;
+    batch.set(docSnap.ref, nextData, { merge: true });
+  });
+  const pendingPurchaseRef = adminDb.collection('stripePurchases').doc(normalizedEmail);
+  const pendingPurchaseSnap = await pendingPurchaseRef.get();
+  const pendingUpdate = buildPendingPurchaseUpdate(pendingPurchaseSnap.data(), {
+    emailLower: normalizedEmail,
+    tier: normalizedTier,
+    sessionId,
+  }, FieldValue.serverTimestamp());
+  if (pendingUpdate) {
+    batch.set(pendingPurchaseRef, pendingUpdate, { merge: true });
+  }
+  await batch.commit();
+}
+
+async function applyPendingPurchasedTierToProfile(uid, email) {
+  if (!adminDb) return;
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) return;
+
+  const pendingPurchaseRef = adminDb.collection('stripePurchases').doc(normalizedEmail);
+  const [pendingPurchaseSnap, profileSnap] = await Promise.all([
+    pendingPurchaseRef.get(),
+    adminDb.collection('userProfiles').doc(uid).get(),
+  ]);
+  if (!pendingPurchaseSnap.exists) return;
+
+  const pendingPurchase = pendingPurchaseSnap.data();
+  const nextData = buildPurchasedTierUpdate(profileSnap.data(), {
+    tier: pendingPurchase?.tier,
+    emailLower: normalizedEmail,
+    sessionId: pendingPurchase?.lastCheckoutSessionId,
+  }, FieldValue.serverTimestamp());
+  if (!nextData) return;
 
   const batch = adminDb.batch();
-  matchingDocs.forEach((docSnap) => {
-    batch.set(docSnap.ref, {
-      tier,
-      purchaseEmail: normalizedEmail,
-      lastCheckoutSessionId: sessionId,
-      updatedAt: FieldValue.serverTimestamp(),
-    }, { merge: true });
-  });
+  batch.set(adminDb.collection('userProfiles').doc(uid), nextData, { merge: true });
+  batch.delete(pendingPurchaseRef);
   await batch.commit();
 }
 
@@ -551,12 +610,32 @@ async function upsertUserLookupRecord({ uid, email, displayName }) {
   if (!adminDb) return;
   const normalizedEmail = normalizeEmail(email);
   const resolvedDisplayName = buildUserDisplayName({ email, displayName });
+  let purchasedTierPatch = null;
+
+  if (normalizedEmail) {
+    const stripePurchaseSnap = await adminDb.collection('stripePurchases').doc(normalizedEmail).get();
+    if (stripePurchaseSnap.exists) {
+      const purchaseData = stripePurchaseSnap.data() ?? {};
+      const purchasedTier = resolveHigherPaidTier(null, purchaseData.tier);
+      if (purchasedTier) {
+        purchasedTierPatch = buildPurchasedTierUpdate({}, {
+          tier: purchasedTier,
+          emailLower: normalizedEmail,
+          sessionId: typeof purchaseData.lastCheckoutSessionId === 'string'
+            ? purchaseData.lastCheckoutSessionId
+            : '',
+        }, FieldValue.serverTimestamp());
+      }
+    }
+  }
+
   const profilePayload = {
     uid,
     email: typeof email === 'string' ? email.trim() : '',
     emailLower: normalizedEmail,
     displayName: resolvedDisplayName,
     updatedAt: FieldValue.serverTimestamp(),
+    ...(purchasedTierPatch ?? {}),
   };
   const lookupPayload = {
     uid,
@@ -615,6 +694,7 @@ registerAdminRoutes(app, {
   authenticateFirebaseUser,
   authenticateAdminRequest,
   syncAdminClaim,
+  reconcilePurchasedTierForUser: applyPendingPurchasedTierToProfile,
   isStrongPassword,
   buildUserDisplayName,
   upsertUserLookupRecord,

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -1,0 +1,64 @@
+const PAID_TIER_PRIORITY = {
+  tier2: 1,
+  tier3: 2,
+};
+
+export function normalizePaidTier(value) {
+  return value === 'tier2' || value === 'tier3' ? value : null;
+}
+
+export function resolveHigherPaidTier(currentTier, incomingTier) {
+  const normalizedCurrent = normalizePaidTier(currentTier);
+  const normalizedIncoming = normalizePaidTier(incomingTier);
+  if (!normalizedCurrent) return normalizedIncoming;
+  if (!normalizedIncoming) return normalizedCurrent;
+  return PAID_TIER_PRIORITY[normalizedIncoming] >= PAID_TIER_PRIORITY[normalizedCurrent]
+    ? normalizedIncoming
+    : normalizedCurrent;
+}
+
+export function shouldPersistPurchaseDetails(currentTier, incomingTier) {
+  const normalizedIncoming = normalizePaidTier(incomingTier);
+  if (!normalizedIncoming) return false;
+  const normalizedCurrent = normalizePaidTier(currentTier);
+  if (!normalizedCurrent) return true;
+  return PAID_TIER_PRIORITY[normalizedIncoming] >= PAID_TIER_PRIORITY[normalizedCurrent];
+}
+
+export function buildPurchasedTierUpdate(currentData, purchase, updatedAt) {
+  const nextTier = resolveHigherPaidTier(currentData?.tier, purchase?.tier);
+  if (!nextTier) return null;
+
+  const nextData = {
+    tier: nextTier,
+    updatedAt,
+  };
+
+  if (shouldPersistPurchaseDetails(currentData?.tier, purchase?.tier)) {
+    if (purchase?.emailLower) {
+      nextData.purchaseEmail = purchase.emailLower;
+    }
+    if (purchase?.sessionId) {
+      nextData.lastCheckoutSessionId = purchase.sessionId;
+    }
+  }
+
+  return nextData;
+}
+
+export function buildPendingPurchaseUpdate(currentData, purchase, updatedAt) {
+  const nextTier = resolveHigherPaidTier(currentData?.tier, purchase?.tier);
+  if (!nextTier || !purchase?.emailLower) return null;
+
+  const nextData = {
+    emailLower: purchase.emailLower,
+    tier: nextTier,
+    updatedAt,
+  };
+
+  if (shouldPersistPurchaseDetails(currentData?.tier, purchase?.tier) && purchase?.sessionId) {
+    nextData.lastCheckoutSessionId = purchase.sessionId;
+  }
+
+  return nextData;
+}

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -9,6 +9,7 @@ export function registerAdminRoutes(app, {
   isStrongPassword,
   buildUserDisplayName,
   upsertUserLookupRecord,
+  reconcilePurchasedTierForUser,
   deleteCollectionDocs,
   deleteQueryDocs,
 }) {
@@ -24,6 +25,15 @@ export function registerAdminRoutes(app, {
 
     try {
       const decodedToken = await authenticateFirebaseUser(req);
+      await upsertUserLookupRecord({
+        uid: decodedToken.uid,
+        email: decodedToken.email ?? '',
+        displayName: decodedToken.name ?? decodedToken.email ?? '',
+      });
+      await reconcilePurchasedTierForUser({
+        uid: decodedToken.uid,
+        email: decodedToken.email ?? '',
+      });
       const claimSync = await syncAdminClaim(decodedToken.uid, decodedToken.email ?? '');
       res.json(claimSync);
     } catch (error) {

--- a/server/routes/payments.js
+++ b/server/routes/payments.js
@@ -62,7 +62,7 @@ export function registerPaymentRoutes(app, {
     }
   });
 
-  app.post('/api/create-checkout-session', checkoutRateLimit, async (req, res) => {
+  app.post('/api/create-checkout-session', express.json({ limit: '256kb' }), checkoutRateLimit, async (req, res) => {
     if (!stripe) {
       res.status(503).json({ error: 'Payment processing is not configured.' });
       return;

--- a/server/test/payments.test.js
+++ b/server/test/payments.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildPendingPurchaseUpdate,
+  buildPurchasedTierUpdate,
+  normalizePaidTier,
+  resolveHigherPaidTier,
+  shouldPersistPurchaseDetails,
+} from '../lib/payments.js';
+
+test('normalizePaidTier accepts only paid tiers', () => {
+  assert.equal(normalizePaidTier('tier2'), 'tier2');
+  assert.equal(normalizePaidTier('tier3'), 'tier3');
+  assert.equal(normalizePaidTier('free'), null);
+  assert.equal(normalizePaidTier(''), null);
+});
+
+test('resolveHigherPaidTier never downgrades a paid tier', () => {
+  assert.equal(resolveHigherPaidTier(null, 'tier2'), 'tier2');
+  assert.equal(resolveHigherPaidTier('tier2', 'tier3'), 'tier3');
+  assert.equal(resolveHigherPaidTier('tier3', 'tier2'), 'tier3');
+  assert.equal(resolveHigherPaidTier('tier3', 'free'), 'tier3');
+});
+
+test('shouldPersistPurchaseDetails only updates purchase metadata for equal or higher tiers', () => {
+  assert.equal(shouldPersistPurchaseDetails(null, 'tier2'), true);
+  assert.equal(shouldPersistPurchaseDetails('tier2', 'tier3'), true);
+  assert.equal(shouldPersistPurchaseDetails('tier3', 'tier2'), false);
+});
+
+test('buildPurchasedTierUpdate preserves higher existing tier while ignoring lower-tier metadata', () => {
+  const update = buildPurchasedTierUpdate({
+    tier: 'tier3',
+    purchaseEmail: 'existing@example.com',
+    lastCheckoutSessionId: 'cs_existing',
+  }, {
+    tier: 'tier2',
+    emailLower: 'buyer@example.com',
+    sessionId: 'cs_new',
+  }, 'timestamp');
+
+  assert.deepEqual(update, {
+    tier: 'tier3',
+    updatedAt: 'timestamp',
+  });
+});
+
+test('buildPurchasedTierUpdate applies purchase metadata for equal or higher tiers', () => {
+  const update = buildPurchasedTierUpdate({
+    tier: 'tier2',
+  }, {
+    tier: 'tier3',
+    emailLower: 'buyer@example.com',
+    sessionId: 'cs_upgrade',
+  }, 'timestamp');
+
+  assert.deepEqual(update, {
+    tier: 'tier3',
+    purchaseEmail: 'buyer@example.com',
+    lastCheckoutSessionId: 'cs_upgrade',
+    updatedAt: 'timestamp',
+  });
+});
+
+test('buildPendingPurchaseUpdate keeps the highest pending tier', () => {
+  const update = buildPendingPurchaseUpdate({
+    tier: 'tier3',
+    lastCheckoutSessionId: 'cs_existing',
+  }, {
+    emailLower: 'buyer@example.com',
+    tier: 'tier2',
+    sessionId: 'cs_new',
+  }, 'timestamp');
+
+  assert.deepEqual(update, {
+    emailLower: 'buyer@example.com',
+    tier: 'tier3',
+    updatedAt: 'timestamp',
+  });
+});
+
+test('buildPendingPurchaseUpdate stores session metadata for new or upgraded purchases', () => {
+  const update = buildPendingPurchaseUpdate({}, {
+    emailLower: 'buyer@example.com',
+    tier: 'tier2',
+    sessionId: 'cs_pending',
+  }, 'timestamp');
+
+  assert.deepEqual(update, {
+    emailLower: 'buyer@example.com',
+    tier: 'tier2',
+    lastCheckoutSessionId: 'cs_pending',
+    updatedAt: 'timestamp',
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- parse JSON bodies for `/api/create-checkout-session` directly on the route so checkout creation works even though payment routes are registered before the global JSON middleware
- make Stripe purchase sync durable by storing unmatched webhook purchases in `stripePurchases` and reconciling them during auth session sync/profile upsert
- prevent lower-tier Stripe events from overwriting a higher paid tier, and add focused server tests for the payment reconciliation helpers

## Testing
- `npm run lint`
- `npm run test:server`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12b22cfa-b1e9-496d-9134-de4287f4cfee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12b22cfa-b1e9-496d-9134-de4287f4cfee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

