### PR TITLE
fix: suppress redundant STRIPE_WEBHOOK_SECRET warning when Stripe is unconfigured

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -538,7 +538,7 @@ if (!FAL_KEY) {
 if (!stripe) {
   console.warn('⚠️  STRIPE_SECRET_KEY environment variable is not set — checkout sessions will be unavailable.');
 } else if (!stripeWebhookSecret) {
-  console.warn('⚠️  STRIPE_WEBHOOK_SECRET environment variable is not set — Stripe webhooks will be unavailable.');
+  console.info('ℹ️  STRIPE_WEBHOOK_SECRET is not set — webhook delivery is disabled. Purchases are still verified via /api/verify-checkout-session.');
 }
 
 const { adminAuth, adminDb } = createFirebaseAdminServices({

--- a/server/index.js
+++ b/server/index.js
@@ -537,8 +537,7 @@ if (!FAL_KEY) {
 }
 if (!stripe) {
   console.warn('⚠️  STRIPE_SECRET_KEY environment variable is not set — checkout sessions will be unavailable.');
-}
-if (!stripeWebhookSecret) {
+} else if (!stripeWebhookSecret) {
   console.warn('⚠️  STRIPE_WEBHOOK_SECRET environment variable is not set — Stripe webhooks will be unavailable.');
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `STRIPE_WEBHOOK_SECRET` warning was emitted unconditionally at server startup as a `console.warn`, even when:
1. `STRIPE_SECRET_KEY` itself was not set (redundant alongside the existing secret-key warning), or
2. The webhook was intentionally left unconfigured since the client-side `/api/verify-checkout-session` endpoint already handles purchase reconciliation.

## Fix

1. Changed the independent `if (!stripeWebhookSecret)` to `else if`, so the message only appears when Stripe is actually enabled but the webhook secret is missing.
2. Downgraded from `console.warn` to `console.info` and rewrote the message to clarify that purchases still work without webhooks — the verify-checkout-session endpoint handles the normal flow.

### Before
```
⚠️  STRIPE_SECRET_KEY environment variable is not set — checkout sessions will be unavailable.
⚠️  STRIPE_WEBHOOK_SECRET environment variable is not set — Stripe webhooks will be unavailable.
```

### After (no Stripe key set)
```
⚠️  STRIPE_SECRET_KEY environment variable is not set — checkout sessions will be unavailable.
```

### After (Stripe key set, no webhook secret)
```
ℹ️  STRIPE_WEBHOOK_SECRET is not set — webhook delivery is disabled. Purchases are still verified via /api/verify-checkout-session.
```

## Context

The Stripe webhook (`/api/stripe/webhook`) and the client-side verify endpoint (`/api/verify-checkout-session`) both call `syncPurchasedTier`. The webhook is a redundant safety net for edge cases (e.g. user closes browser before redirect). The verify endpoint already handles the normal checkout flow, so a missing webhook secret is a valid configuration choice, not an error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5f7fe9e-23c6-4a1a-bfc6-ae23c98f3e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5f7fe9e-23c6-4a1a-bfc6-ae23c98f3e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

