### PR TITLE
feat: Charge Up system — 8-hour free forge timer with capped rarity

### DIFF
--- a/docs/AGENT_STATUS.md
+++ b/docs/AGENT_STATUS.md
@@ -1,0 +1,28 @@
+# Agent Status
+
+> Updated at the end of each sprint by the responsible agent.
+
+---
+
+## Gamma Agent
+
+### Sprint 0 — Foundation
+
+| Deliverable | Status |
+|---|---|
+| Audit `firestore.rules` and `firestore.indexes.json` | ✅ shipped |
+| Document current collection shapes in `docs/DATA_MODEL.md` | ✅ shipped |
+| Create shared contract file `src/lib/sharedTypes.ts` | ✅ shipped |
+| Create feature flags registry `src/lib/featureFlags.ts` | ✅ shipped |
+| Create server stubs: `battlePass.js`, `ranked.js`, `crews.js`, `dailyRewards.js` | ✅ shipped |
+| Add read-only Firestore stubs: `dailyStreaks`, `missions`, `battlePass`, `crews`, `rankedSeasons`, `shareLinks` | ✅ shipped |
+
+---
+
+## Charlie Agent
+
+### Sprint 0
+
+| Deliverable | Status |
+|---|---|
+| _(awaiting Charlie's first sprint)_ | — |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,301 @@
+# Firestore Data Model
+
+> Auto-generated from `firestore.rules`, `firestore.indexes.json`, and `src/lib/types.ts`.
+> Last updated: Sprint 0.
+
+---
+
+## Collections Overview
+
+| Collection | Scope | Key | Access Pattern |
+|---|---|---|---|
+| `users/{uid}/cards` | Sub-collection | `cardId` | Owner read/write |
+| `users/{uid}/decks` | Sub-collection | `deckId` | Owner read/write |
+| `userProfiles` | Top-level | `uid` | Owner + admin read; validated create/update |
+| `userLookup` | Top-level | `uid` | Any authed read; owner create/update |
+| `imageCache` | Top-level | `cacheKey` (layer+seed hash) | Public read; authed create; no update; admin delete |
+| `trades` | Top-level | `tradeId` | Participant + pending-browse read; offerer create; recipient/offerer update |
+| `referralClaims` | Top-level | `{referrerUid}_{visitorKey}` | Referrer read; anyone create (no self-referral); immutable |
+| `arena` | Top-level | `uid` | Any authed read; owner write/delete |
+| `battleResults` | Top-level | `resultId` | Participant read; server-only write |
+| `leaderboard` | Top-level | `uid` | Any authed read; owner write |
+| `factionImages` | Top-level | `factionKey` (slug) | Public read; admin write/delete |
+
+---
+
+## Document Shapes
+
+### `users/{uid}/cards/{cardId}` — CardPayload
+
+Owner-only sub-collection. Each document mirrors `CardPayload` from `src/lib/types.ts`.
+
+```
+{
+  id: string,                   // same as doc ID
+  version: string,
+  seed: string,                 // "frameSeed::backgroundSeed::characterSeed"
+  frameSeed: string,
+  backgroundSeed: string,
+  characterSeed: string,
+  prompts: {
+    archetype: Archetype,
+    rarity: Rarity,
+    style: Style,
+    vibe?: Vibe,                // deprecated
+    district: District,
+    accentColor: string,
+    gender: Gender,
+    ageGroup: AgeGroup,
+    bodyType: BodyType,
+    hairLength?: HairLength,
+    hairColor?: HairColor,
+    skinTone?: SkinTone,
+    faceCharacter?: FaceCharacter,
+    shoeStyle?: ShoeStyle,
+  },
+  identity: {
+    name: string,
+    crew: Faction,
+    serialNumber: string,
+    age?: string,
+  },
+  stats: {
+    speed: number,
+    stealth: number,
+    tech: number,
+    grit: number,
+    rep: number,
+  },
+  traits: {
+    passiveTrait: { name: string, description: string },
+    activeAbility: { name: string, description: string },
+    personalityTags: string[],
+  },
+  visuals: {
+    helmetStyle: string,
+    boardStyle: string,
+    jacketStyle: string,
+    colorScheme: string,
+    accentColor: string,
+    storagePackStyle: string,
+  },
+  flavorText: string,
+  tags: string[],
+  ozzies?: number,              // $1.00–$100.00
+  board?: BoardConfig,
+  boardLoadout?: BoardLoadout,
+  boardImageUrl?: string,
+  createdAt: string,
+  imageUrl?: string,            // legacy single-image
+  backgroundImageUrl?: string,
+  characterImageUrl?: string,
+  frameImageUrl?: string,
+  conlang?: ConlangOverlay,
+  discovery?: {
+    displayArchetype?: string,
+    revealedFaction?: Faction,
+    isSecretReveal?: boolean,
+    logoMark?: string,
+    unlockedAt?: string,
+  },
+}
+```
+
+### `users/{uid}/decks/{deckId}` — DeckPayload
+
+Owner-only sub-collection.
+
+```
+{
+  id: string,
+  version: string,
+  name: string,
+  cards: CardPayload[],         // embedded card array
+  createdAt: string,
+  updatedAt: string,
+  sortOrder?: number,
+  battleReady?: boolean,
+}
+```
+
+### `userProfiles/{uid}`
+
+Private profile. Owner + admin read. Validated field allowlist on create/update.
+
+```
+{
+  uid: string,
+  email: string,
+  emailLower: string,
+  displayName: string,
+  discoveredFactions: any,      // faction discovery state
+  updatedAt: Timestamp,
+}
+```
+
+**Create allowlist:** `uid`, `email`, `emailLower`, `displayName`, `discoveredFactions`, `updatedAt`.
+**Update allowlist:** `email`, `emailLower`, `displayName`, `discoveredFactions`, `updatedAt`.
+
+### `userLookup/{uid}`
+
+Minimal public directory for trade recipient lookup.
+
+```
+{
+  uid: string,
+  emailLower: string,
+  displayName: string,
+  updatedAt: Timestamp,
+}
+```
+
+### `imageCache/{cacheKey}`
+
+Fal.ai image URL cache keyed by layer+seed. Public read, authed create, immutable.
+
+```
+{
+  imageUrl: string,             // must match fal.media or Firebase Storage URL pattern
+  createdAt: Timestamp,
+  prompt?: string,              // ≤ 512 chars
+  layer?: string,               // ≤ 64 chars
+  seed?: string,                // ≤ 512 chars
+}
+```
+
+### `trades/{tradeId}` — TradePayload
+
+Peer-to-peer card trades and Community Market listings.
+
+```
+{
+  id: string,
+  fromUid: string,
+  fromEmail: string,
+  toUid: string,
+  toEmail: string,
+  offeredCardId?: string,
+  offeredCard: CardPayload,     // embedded snapshot
+  status: "pending" | "accepted" | "declined" | "cancelled",
+  createdAt: string,
+  updatedAt: string,
+}
+```
+
+### `referralClaims/{referrerUid}_{visitorKey}`
+
+Immutable referral tracking. Unauthenticated create allowed (no self-referral).
+
+```
+{
+  referrerUid: string,
+  visitorKey: string,
+  claimedAt: Timestamp,
+}
+```
+
+### `arena/{uid}` — ArenaEntry
+
+Public battle-ready deck listings. Owner write/delete.
+
+```
+{
+  uid: string,
+  displayName: string,
+  deckId: string,
+  deckName: string,
+  cardCount: number,
+  battleSummary?: {
+    deckPower: number,
+    strongestStat: StatKey,
+    strongestStatTotal: number,
+    synergyBonusPct: number,
+    archetypeHint: string,
+  },
+  battleDeck?: BattleCardSnapshot[],
+  readiedAt: string,
+}
+```
+
+### `battleResults/{resultId}` — BattleResult
+
+Server-written battle outcomes. Participant read only.
+
+```
+{
+  id: string,
+  challengerUid: string,
+  challengerDeckId: string,
+  challengerDeckName: string,
+  defenderUid: string,
+  defenderDeckId: string,
+  defenderDeckName: string,
+  winnerUid: string,
+  challengerScore: number,
+  defenderScore: number,
+  wagerPoints: number,
+  winningDeckCardIds: string[],
+  challengerCardResolutions: BattleCardResolution[],
+  defenderCardResolutions: BattleCardResolution[],
+  createdAt: string,
+}
+```
+
+### `leaderboard/{uid}` — LeaderboardEntry
+
+Public leaderboard. Owner write.
+
+```
+{
+  uid: string,
+  displayName: string,
+  deckName: string,
+  cardCount: number,
+  deckPower: number,
+  ozzies: number,
+  strongestStat: StatKey,
+  strongestStatTotal: number,
+  synergyBonusPct: number,
+  archetypeHint: string,
+  updatedAt: string,
+}
+```
+
+### `factionImages/{factionKey}`
+
+Faction background images. Public read, admin write.
+
+```
+{
+  imageUrl: string,             // faction background image URL
+  updatedAt?: Timestamp,
+}
+```
+
+---
+
+## Composite Indexes (`firestore.indexes.json`)
+
+| Collection | Fields | Query Scope |
+|---|---|---|
+| `trades` | `status` ASC, `createdAt` DESC | COLLECTION |
+| `leaderboard` | `deckPower` DESC, `ozzies` DESC | COLLECTION |
+
+---
+
+## New Collections (Sprint 0 — read-only stubs)
+
+The following collections are defined in `firestore.rules` as read-only stubs
+(authenticated read, no client write) pending full implementation:
+
+| Collection | Purpose | Owner |
+|---|---|---|
+| `dailyStreaks/{uid}` | Daily login streak tracking | Gamma |
+| `missions/{missionId}` | Per-user mission / quest progress | Gamma |
+| `battlePass/{uid}` | Battle pass tier + XP state | Gamma |
+| `crews/{crewId}` | Player crew / guild membership | Charlie |
+| `rankedSeasons/{seasonId}` | Ranked season config + standings | Charlie |
+| `shareLinks/{linkId}` | Shareable card / deck links | Charlie |
+
+Document shapes for these collections will be defined in `src/lib/sharedTypes.ts`
+as implementation progresses.

--- a/firestore.rules
+++ b/firestore.rules
@@ -165,6 +165,13 @@ service cloud.firestore {
     // until the corresponding feature passes QA and the flag is enabled.
     // ══════════════════════════════════════════════════════════════════════════
 
+    // ── Charge Ups ─────────────────────────────────────────────────────────
+    // Per-user Charge Up state. Doc ID = uid.
+    match /chargeUps/{uid} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow create, update, delete: if false;
+    }
+
     // ── Daily Streaks ────────────────────────────────────────────────────────
     // Per-user daily login streak. Doc ID = uid.
     match /dailyStreaks/{uid} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -159,5 +159,54 @@ service cloud.firestore {
         && request.auth.token.admin == true;
     }
 
+    // ══════════════════════════════════════════════════════════════════════════
+    // New collections — read-only stubs (Sprint 0)
+    // Client reads allowed for authenticated users; all writes are server-only
+    // until the corresponding feature passes QA and the flag is enabled.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    // ── Daily Streaks ────────────────────────────────────────────────────────
+    // Per-user daily login streak. Doc ID = uid.
+    match /dailyStreaks/{uid} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow create, update, delete: if false;
+    }
+
+    // ── Missions ─────────────────────────────────────────────────────────────
+    // Per-user mission / quest progress.
+    match /missions/{missionId} {
+      allow read: if request.auth != null
+        && resource.data.uid == request.auth.uid;
+      allow create, update, delete: if false;
+    }
+
+    // ── Battle Pass ──────────────────────────────────────────────────────────
+    // Per-user battle pass tier + XP state. Doc ID = uid.
+    match /battlePass/{uid} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow create, update, delete: if false;
+    }
+
+    // ── Crews ────────────────────────────────────────────────────────────────
+    // Player crew / guild. Any authed user can browse; writes are server-only.
+    match /crews/{crewId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
+
+    // ── Ranked Seasons ───────────────────────────────────────────────────────
+    // Season config + standings. Any authed user can read.
+    match /rankedSeasons/{seasonId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
+
+    // ── Share Links ──────────────────────────────────────────────────────────
+    // Publicly viewable card / deck share links.
+    match /shareLinks/{linkId} {
+      allow read: if true;
+      allow create, update, delete: if false;
+    }
+
   }
 }

--- a/server/battlePass.js
+++ b/server/battlePass.js
@@ -1,0 +1,16 @@
+/**
+ * server/battlePass.js — Battle pass progression handlers.
+ * Stubbed as no-op handlers so routes can be wired without errors.
+ */
+
+export function getBattlePassState(_req, res) {
+  res.json({ ok: true, data: null });
+}
+
+export function claimBattlePassReward(_req, res) {
+  res.json({ ok: true, data: null });
+}
+
+export function advanceBattlePassTier(_req, res) {
+  res.json({ ok: true, data: null });
+}

--- a/server/crews.js
+++ b/server/crews.js
@@ -1,0 +1,20 @@
+/**
+ * server/crews.js — Crew / guild management handlers.
+ * Stubbed as no-op handlers so routes can be wired without errors.
+ */
+
+export function getCrew(_req, res) {
+  res.json({ ok: true, data: null });
+}
+
+export function createCrew(_req, res) {
+  res.json({ ok: true, data: null });
+}
+
+export function joinCrew(_req, res) {
+  res.json({ ok: true, data: null });
+}
+
+export function leaveCrew(_req, res) {
+  res.json({ ok: true, data: null });
+}

--- a/server/dailyRewards.js
+++ b/server/dailyRewards.js
@@ -1,0 +1,12 @@
+/**
+ * server/dailyRewards.js — Daily login reward / streak handlers.
+ * Stubbed as no-op handlers so routes can be wired without errors.
+ */
+
+export function getDailyStreak(_req, res) {
+  res.json({ ok: true, data: null });
+}
+
+export function claimDailyReward(_req, res) {
+  res.json({ ok: true, data: null });
+}

--- a/server/ranked.js
+++ b/server/ranked.js
@@ -1,0 +1,16 @@
+/**
+ * server/ranked.js — Ranked season handlers.
+ * Stubbed as no-op handlers so routes can be wired without errors.
+ */
+
+export function getCurrentSeason(_req, res) {
+  res.json({ ok: true, data: null });
+}
+
+export function getSeasonStandings(_req, res) {
+  res.json({ ok: true, data: [] });
+}
+
+export function submitRankedResult(_req, res) {
+  res.json({ ok: true, data: null });
+}

--- a/src/components/ChargeUpIndicator.tsx
+++ b/src/components/ChargeUpIndicator.tsx
@@ -1,0 +1,33 @@
+import type { ChargeUpState } from "../hooks/useChargeUp";
+
+interface ChargeUpIndicatorProps {
+  chargeUp: ChargeUpState;
+  compact?: boolean;
+}
+
+export function ChargeUpIndicator({ chargeUp, compact }: ChargeUpIndicatorProps) {
+  if (!chargeUp.enabled) return null;
+
+  return (
+    <div
+      className={`charge-up-indicator${chargeUp.available ? " charge-up-indicator--ready" : ""}${compact ? " charge-up-indicator--compact" : ""}`}
+      role="status"
+      aria-live="polite"
+      title={
+        chargeUp.available
+          ? "Free Charge Up forge available! Punch Skater and Apprentice rarities only."
+          : `Charge Up recharging: ${chargeUp.countdown}`
+      }
+    >
+      <span className="charge-up-indicator__icon" aria-hidden="true">
+        {chargeUp.available ? "\u26A1" : "\u{1F50B}"}
+      </span>
+      <span className="charge-up-indicator__label">
+        {chargeUp.available ? "Charge Up Ready" : chargeUp.countdown}
+      </span>
+      {chargeUp.available && !compact && (
+        <span className="charge-up-indicator__hint">Free forge (capped rarity)</span>
+      )}
+    </div>
+  );
+}

--- a/src/context/TierContext.tsx
+++ b/src/context/TierContext.tsx
@@ -13,6 +13,7 @@ import {
   type TierLevel,
 } from "../lib/tiers";
 import { claimReferral, REFERRAL_CREDITS_KEY } from "../services/referrals";
+import { useChargeUp, type ChargeUpState } from "../hooks/useChargeUp";
 import { useAuth } from "./AuthContext";
 import { db } from "../lib/firebase";
 import { resolveApiUrl } from "../lib/apiUrls";
@@ -47,10 +48,12 @@ interface TierContextValue {
   email: string;
   /** Number of referral-earned generate credits remaining. */
   generateCredits: number;
-  /** True when the user may forge a card (paid tier OR has credits OR free card available). */
+  /** True when the user may forge a card (paid tier OR has credits OR free card available OR charge up). */
   canForge: boolean;
   /** True when the free tier's one complimentary card has already been used. */
   freeCardUsed: boolean;
+  /** Charge Up timer state (8-hour free forge). */
+  chargeUp: ChargeUpState;
   setTier: (level: TierLevel, email?: string) => void;
   logout: () => void;
   /** Consume one generate credit (call after a successful forge on free tier). */
@@ -240,7 +243,8 @@ export function TierProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  const canForge = TIERS[tier].canGenerate || generateCredits > 0 || (tier === "free" && !freeCardUsed);
+  const chargeUp = useChargeUp();
+  const canForge = TIERS[tier].canGenerate || generateCredits > 0 || (tier === "free" && !freeCardUsed) || chargeUp.available;
 
   const setTier = useCallback((level: TierLevel, newEmail?: string) => {
     setTierState(level);
@@ -275,7 +279,7 @@ export function TierProvider({ children }: { children: ReactNode }) {
 
   return (
     <TierContext.Provider value={{
-      tier, email, generateCredits, canForge, freeCardUsed,
+      tier, email, generateCredits, canForge, freeCardUsed, chargeUp,
       setTier, logout, consumeCredit, markFreeCardUsed,
       showUpgradeModal, openUpgradeModal, closeUpgradeModal,
     }}>

--- a/src/hooks/useChargeUp.ts
+++ b/src/hooks/useChargeUp.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  consumeCharge,
+  formatCountdown,
+  getChargeStatus,
+  isChargeAllowedRarity,
+} from "../lib/chargeUp";
+import { isEnabled } from "../lib/featureFlags";
+import type { Rarity } from "../lib/types";
+
+const TICK_INTERVAL_MS = 1000;
+
+export interface ChargeUpState {
+  enabled: boolean;
+  available: boolean;
+  countdown: string;
+  msUntilReady: number;
+  useCharge: () => void;
+  isRarityAllowed: (rarity: Rarity) => boolean;
+}
+
+export function useChargeUp(): ChargeUpState {
+  const enabled = isEnabled("CHARGE_UP");
+  const [now, setNow] = useState(Date.now);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [enabled]);
+
+  const status = useMemo(() => getChargeStatus(now), [now]);
+
+  const useCharge = useCallback(() => {
+    consumeCharge();
+    setNow(Date.now());
+  }, []);
+
+  const isRarityAllowed = useCallback(
+    (rarity: Rarity) => isChargeAllowedRarity(rarity),
+    [],
+  );
+
+  return {
+    enabled,
+    available: enabled && status.available,
+    countdown: formatCountdown(status.msUntilReady),
+    msUntilReady: status.msUntilReady,
+    useCharge,
+    isRarityAllowed,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -722,6 +722,54 @@ button { cursor: pointer; font-family: var(--font); transition: all 0.2s ease; }
   margin-bottom: 12px;
 }
 
+/* ── Charge Up indicator ───────────────────────────────────────────────────── */
+.charge-up-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: linear-gradient(135deg, rgba(10, 18, 28, 0.95), rgba(20, 10, 30, 0.92));
+  font-size: 14px;
+  color: var(--text-dim);
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.charge-up-indicator--ready {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 12px rgba(0, 255, 136, 0.15), inset 0 0 20px rgba(0, 255, 136, 0.04);
+  animation: charge-pulse 2s ease-in-out infinite;
+}
+
+.charge-up-indicator--compact {
+  padding: 4px 10px;
+  font-size: 12px;
+  margin-bottom: 0;
+}
+
+.charge-up-indicator__icon {
+  font-size: 1.2em;
+}
+
+.charge-up-indicator__label {
+  font-family: var(--font);
+  font-weight: bold;
+  letter-spacing: 0.05em;
+}
+
+.charge-up-indicator__hint {
+  font-size: 0.85em;
+  opacity: 0.7;
+}
+
+@keyframes charge-pulse {
+  0%, 100% { box-shadow: 0 0 12px rgba(0, 255, 136, 0.15), inset 0 0 20px rgba(0, 255, 136, 0.04); }
+  50% { box-shadow: 0 0 20px rgba(0, 255, 136, 0.3), inset 0 0 30px rgba(0, 255, 136, 0.08); }
+}
+
 .forge-welcome-panel {
   border-color: rgba(0, 255, 136, 0.32);
   background:

--- a/src/lib/chargeUp.ts
+++ b/src/lib/chargeUp.ts
@@ -1,0 +1,68 @@
+/**
+ * chargeUp.ts — "Charge Up" free forge timer.
+ *
+ * Every 8 hours a player earns one free forge attempt with a capped rarity
+ * ceiling (Punch Skater / Apprentice only — no Rare/Legendary).
+ * The charge persists in localStorage and resets on use.
+ */
+
+import type { Rarity } from "./types";
+
+export const CHARGE_INTERVAL_MS = 8 * 60 * 60 * 1000;
+export const CHARGE_MAX_RARITY: Rarity = "Apprentice";
+export const CHARGE_ALLOWED_RARITIES: readonly Rarity[] = ["Punch Skater", "Apprentice"];
+
+const CHARGE_STORAGE_KEY = "skpd_charge_up";
+
+interface ChargeState {
+  lastUsedAt: number;
+}
+
+function loadChargeState(): ChargeState {
+  try {
+    const raw = localStorage.getItem(CHARGE_STORAGE_KEY);
+    if (!raw) return { lastUsedAt: 0 };
+    const parsed = JSON.parse(raw) as Partial<ChargeState>;
+    return { lastUsedAt: typeof parsed.lastUsedAt === "number" ? parsed.lastUsedAt : 0 };
+  } catch {
+    return { lastUsedAt: 0 };
+  }
+}
+
+function saveChargeState(state: ChargeState): void {
+  localStorage.setItem(CHARGE_STORAGE_KEY, JSON.stringify(state));
+}
+
+export function getChargeStatus(now: number = Date.now()): {
+  available: boolean;
+  msUntilReady: number;
+  lastUsedAt: number;
+} {
+  const state = loadChargeState();
+  const elapsed = now - state.lastUsedAt;
+  const available = elapsed >= CHARGE_INTERVAL_MS;
+  const msUntilReady = available ? 0 : CHARGE_INTERVAL_MS - elapsed;
+  return { available, msUntilReady, lastUsedAt: state.lastUsedAt };
+}
+
+export function consumeCharge(): void {
+  saveChargeState({ lastUsedAt: Date.now() });
+}
+
+export function isChargeAllowedRarity(rarity: Rarity): boolean {
+  return (CHARGE_ALLOWED_RARITIES as readonly string[]).includes(rarity);
+}
+
+export function clampToChargeRarity(rarity: Rarity): Rarity {
+  return isChargeAllowedRarity(rarity) ? rarity : CHARGE_MAX_RARITY;
+}
+
+export function formatCountdown(ms: number): string {
+  if (ms <= 0) return "Ready!";
+  const totalSeconds = Math.ceil(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,45 @@
+/**
+ * featureFlags.ts — Central feature-flag registry.
+ *
+ * Every new system ships behind a flag here. Default is `false` in production
+ * until QA passes. Flags can be toggled at build time via environment
+ * variables (VITE_FF_*) or at runtime through an admin panel (future).
+ *
+ * Naming convention:  SCREAMING_SNAKE matching the system name.
+ */
+
+function envFlag(key: string, fallback: boolean = false): boolean {
+  if (typeof import.meta !== "undefined" && import.meta.env) {
+    const val = (import.meta.env as Record<string, string | undefined>)[key];
+    if (val === "true" || val === "1") return true;
+    if (val === "false" || val === "0") return false;
+  }
+  return fallback;
+}
+
+export const featureFlags = {
+  /** Daily login streaks + rewards UI. @owner gamma */
+  DAILY_REWARDS: envFlag("VITE_FF_DAILY_REWARDS", false),
+
+  /** Mission / quest tracker panel. @owner gamma */
+  MISSIONS: envFlag("VITE_FF_MISSIONS", false),
+
+  /** Battle pass tier progression + premium track. @owner gamma */
+  BATTLE_PASS: envFlag("VITE_FF_BATTLE_PASS", false),
+
+  /** Crew / guild system. @owner charlie */
+  CREWS: envFlag("VITE_FF_CREWS", false),
+
+  /** Ranked seasons + seasonal leaderboard. @owner charlie */
+  RANKED_SEASONS: envFlag("VITE_FF_RANKED_SEASONS", false),
+
+  /** Shareable card / deck links. @owner charlie */
+  SHARE_LINKS: envFlag("VITE_FF_SHARE_LINKS", false),
+} as const;
+
+export type FeatureFlagKey = keyof typeof featureFlags;
+
+/** Runtime check — use in components / hooks to gate UI. */
+export function isEnabled(flag: FeatureFlagKey): boolean {
+  return featureFlags[flag];
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -18,6 +18,9 @@ function envFlag(key: string, fallback: boolean = false): boolean {
 }
 
 export const featureFlags = {
+  /** 8-hour free forge timer ("Charge Up"). @owner gamma */
+  CHARGE_UP: envFlag("VITE_FF_CHARGE_UP", false),
+
   /** Daily login streaks + rewards UI. @owner gamma */
   DAILY_REWARDS: envFlag("VITE_FF_DAILY_REWARDS", false),
 

--- a/src/lib/sharedTypes.ts
+++ b/src/lib/sharedTypes.ts
@@ -10,6 +10,16 @@
 
 import type { CardPayload } from "./types";
 
+// ── Charge Up (Gamma) ────────────────────────────────────────────────────────
+
+/** @sprint 1 @owner gamma — Charge Up forge event persisted per-user. Doc ID = uid. */
+export interface ChargeUpState {
+  uid: string;
+  lastUsedAt: string;
+  totalChargesUsed: number;
+  updatedAt: string;
+}
+
 // ── Daily Streaks (Gamma) ────────────────────────────────────────────────────
 
 /** @sprint 0 @owner gamma — Per-user daily login streak. Doc ID = uid. */

--- a/src/lib/sharedTypes.ts
+++ b/src/lib/sharedTypes.ts
@@ -1,0 +1,127 @@
+/**
+ * sharedTypes.ts — Append-only contract file shared between Gamma and Charlie agents.
+ *
+ * Rules:
+ *  1. Never remove or rename an existing type.
+ *  2. New fields on existing interfaces must be optional (?:).
+ *  3. Add new types at the bottom of the relevant section.
+ *  4. Every addition must include a JSDoc comment with the sprint and owner.
+ */
+
+import type { CardPayload } from "./types";
+
+// ── Daily Streaks (Gamma) ────────────────────────────────────────────────────
+
+/** @sprint 0 @owner gamma — Per-user daily login streak. Doc ID = uid. */
+export interface DailyStreak {
+  uid: string;
+  currentStreak: number;
+  longestStreak: number;
+  lastClaimDate: string;
+  totalClaims: number;
+  updatedAt: string;
+}
+
+// ── Missions (Gamma) ─────────────────────────────────────────────────────────
+
+/** @sprint 0 @owner gamma */
+export type MissionStatus = "active" | "completed" | "expired";
+
+/** @sprint 0 @owner gamma */
+export interface Mission {
+  id: string;
+  uid: string;
+  title: string;
+  description: string;
+  type: string;
+  target: number;
+  progress: number;
+  status: MissionStatus;
+  rewardXp: number;
+  createdAt: string;
+  expiresAt?: string;
+  completedAt?: string;
+}
+
+// ── Battle Pass (Gamma) ──────────────────────────────────────────────────────
+
+/** @sprint 0 @owner gamma */
+export interface BattlePassState {
+  uid: string;
+  seasonId: string;
+  tier: number;
+  xp: number;
+  xpToNextTier: number;
+  isPremium: boolean;
+  claimedRewards: number[];
+  updatedAt: string;
+}
+
+// ── Crews (Charlie) ──────────────────────────────────────────────────────────
+
+/** @sprint 0 @owner charlie */
+export interface Crew {
+  id: string;
+  name: string;
+  tag: string;
+  leaderUid: string;
+  memberUids: string[];
+  maxMembers: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Ranked Seasons (Charlie) ─────────────────────────────────────────────────
+
+/** @sprint 0 @owner charlie */
+export interface RankedSeason {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  isActive: boolean;
+  createdAt: string;
+}
+
+/** @sprint 0 @owner charlie */
+export interface RankedEntry {
+  uid: string;
+  seasonId: string;
+  displayName: string;
+  rating: number;
+  wins: number;
+  losses: number;
+  rank: number;
+  updatedAt: string;
+}
+
+// ── Share Links (Charlie) ────────────────────────────────────────────────────
+
+/** @sprint 0 @owner charlie */
+export type ShareLinkType = "card" | "deck";
+
+/** @sprint 0 @owner charlie */
+export interface ShareLink {
+  id: string;
+  ownerUid: string;
+  type: ShareLinkType;
+  /** ID of the card or deck being shared. */
+  targetId: string;
+  /** Snapshot of the shared content at link-creation time. */
+  snapshot: Partial<CardPayload> | Record<string, unknown>;
+  views: number;
+  createdAt: string;
+  expiresAt?: string;
+}
+
+// ── Shared enums / constants ─────────────────────────────────────────────────
+
+/** @sprint 0 @owner gamma — XP reward tiers used across battle pass, missions, and daily rewards. */
+export const XP_REWARD = {
+  DAILY_LOGIN: 50,
+  MISSION_COMPLETE: 100,
+  BATTLE_WIN: 75,
+  BATTLE_LOSS: 25,
+} as const;
+
+export type XpRewardKey = keyof typeof XP_REWARD;

--- a/src/pages/CardForge.tsx
+++ b/src/pages/CardForge.tsx
@@ -1,3 +1,4 @@
+import { ChargeUpIndicator } from "../components/ChargeUpIndicator";
 import { ForgeControlsPanel } from "./cardForge/ForgeControlsPanel";
 import { ForgePreviewPanel } from "./cardForge/ForgePreviewPanel";
 import { ForgeResultOverlays } from "./cardForge/ForgeResultOverlays";
@@ -23,6 +24,7 @@ export function CardForge() {
     boardImageLoading,
     canForge,
     characterBlend,
+    chargeUp,
     closeWelcome,
     downloading,
     forging,
@@ -94,6 +96,8 @@ export function CardForge() {
           Random Skater
         </button>
       </div>
+
+      <ChargeUpIndicator chargeUp={chargeUp} />
 
       <div className="forge-layout">
         <ForgeControlsPanel

--- a/src/pages/cardForge/useCardForgeController.ts
+++ b/src/pages/cardForge/useCardForgeController.ts
@@ -22,6 +22,7 @@ export function useCardForgeController() {
     boardImageLoading: forge.boardImageLoading,
     canForge: forge.canForge,
     characterBlend: forge.characterBlend,
+    chargeUp: forge.chargeUp,
     closeWelcome: navigation.closeWelcome,
     downloading: save.downloading,
     forging: forge.forging,

--- a/src/pages/cardForge/useForgeGeneration.ts
+++ b/src/pages/cardForge/useForgeGeneration.ts
@@ -16,6 +16,8 @@ import { buildBackgroundPrompt, buildCharacterPrompt, buildFramePrompt } from ".
 import { useTier } from "../../context/TierContext";
 import { useAuth } from "../../context/AuthContext";
 import { useFactionDiscovery } from "../../hooks/useFactionDiscovery";
+import { clampToChargeRarity } from "../../lib/chargeUp";
+import { TIERS } from "../../lib/tiers";
 import type { Archetype, CardPayload, CardPrompts, Faction } from "../../lib/types";
 import { createCharacterLayerValidator, useForgeLayers } from "./useForgeLayers";
 import {
@@ -29,7 +31,7 @@ import { applyPreviewUpdates, buildRandomizedBoardConfig, buildRandomizedPrompts
 const ARCHETYPE_VALUES = FORGE_ARCHETYPE_OPTIONS.map((option) => option.value);
 
 export function useForgeGeneration() {
-  const { tier, canForge, generateCredits, consumeCredit, openUpgradeModal, freeCardUsed, markFreeCardUsed } = useTier();
+  const { tier, canForge, generateCredits, consumeCredit, openUpgradeModal, freeCardUsed, markFreeCardUsed, chargeUp } = useTier();
   const { user } = useAuth();
   const { hasFaction, unlockFaction } = useFactionDiscovery();
   const [prompts, setPrompts] = useState<CardPrompts>({
@@ -79,7 +81,9 @@ export function useForgeGeneration() {
     abortRef.current = controller;
     const { signal } = controller;
 
-    const forgePrompts = { ...prompts, style: resolveArchetypeStyle(prompts.archetype, prompts.style) };
+    const isChargeForge = chargeUp.available && !TIERS[tier].canGenerate && !(tier === "free" && !freeCardUsed) && generateCredits <= 0;
+    const effectiveRarity = isChargeForge ? clampToChargeRarity(prompts.rarity) : prompts.rarity;
+    const forgePrompts = { ...prompts, rarity: effectiveRarity, style: resolveArchetypeStyle(prompts.archetype, prompts.style) };
     const displayArchetype = getForgeArchetypeLabel(forgePrompts.archetype);
     const secretFaction = tier === "free" ? null : resolveSecretFaction(forgePrompts);
     const generationPrompts =
@@ -103,7 +107,9 @@ export function useForgeGeneration() {
       setRevealedFaction(null);
     }
 
-    if (tier === "free" && !freeCardUsed) {
+    if (isChargeForge) {
+      chargeUp.useCharge();
+    } else if (tier === "free" && !freeCardUsed) {
       markFreeCardUsed();
     } else if (generateCredits > 0) {
       consumeCredit();
@@ -181,6 +187,7 @@ export function useForgeGeneration() {
     abortRef,
     boardConfig,
     canForge,
+    chargeUp,
     consumeCredit,
     freeCardUsed,
     generateCredits,
@@ -235,6 +242,7 @@ export function useForgeGeneration() {
     boardImageLoading,
     canForge,
     characterBlend,
+    chargeUp,
     forging,
     freeCardUsed,
     generated,
@@ -263,6 +271,7 @@ export function useForgeGeneration() {
     boardImageLoading,
     canForge,
     characterBlend,
+    chargeUp,
     forging,
     freeCardUsed,
     generated,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the "Charge Up" mechanic — every 8 hours players earn one free forge attempt, capped at Apprentice rarity. This is the first cadence hook in the Daily → Weekly → Seasonal engagement loop, designed to bring players back 2–3x/day.

## How It Works

1. Every 8 hours, the `ChargeUpIndicator` shows "Charge Up Ready" with a lightning bolt and pulse animation
2. When ready, the player can forge a card for free — rarity is automatically clamped to Punch Skater or Apprentice (no Rare/Legendary via charge)
3. After use, the timer resets and counts down to the next available charge
4. The charge timer persists via `localStorage` and is independent of tier/credits

## Integration Points

- **`canForge` extended**: `TierContext` now considers `chargeUp.available` — players who are out of credits AND have used their free card can still forge if a charge is ready
- **Credit priority**: Charge Up is only consumed when no other forge method is available (paid tier takes priority, then free card, then credits, then charge)
- **Rarity clamping**: When forging via Charge Up, `clampToChargeRarity()` ensures the generated card is at most Apprentice rarity

## Files Changed

| File | Change |
|---|---|
| `src/lib/chargeUp.ts` | Core timer logic, rarity clamping, `localStorage` persistence |
| `src/hooks/useChargeUp.ts` | React hook with live 1-second countdown ticker |
| `src/components/ChargeUpIndicator.tsx` | UI component: timer countdown or "Ready" state |
| `src/context/TierContext.tsx` | Extended `canForge` to include charge availability |
| `src/pages/cardForge/useForgeGeneration.ts` | Detects charge forge, clamps rarity, consumes charge |
| `src/pages/cardForge/useCardForgeController.ts` | Passes `chargeUp` through controller |
| `src/pages/CardForge.tsx` | Mounts `ChargeUpIndicator` below quick actions |
| `src/lib/featureFlags.ts` | Added `CHARGE_UP` flag (default `false`) |
| `src/lib/sharedTypes.ts` | Added `ChargeUpState` interface for Firestore persistence |
| `firestore.rules` | Added `chargeUps/{uid}` read-only stub rule |
| `src/index.css` | Charge Up indicator styles with pulse animation |

## Feature Flag

Ships behind `VITE_FF_CHARGE_UP`. Set to `true` to enable. Default `false` in production until QA.

## Testing

- ESLint: passes clean
- TypeScript: `tsc --noEmit` passes clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a90f8bf-f3f8-470a-b317-07e7b2f0dc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a90f8bf-f3f8-470a-b317-07e7b2f0dc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

