### PR TITLE
Build subscription tier packages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,7 @@ VITE_CRAFTLINGUA_RESOLVE_API_URL=
 
 # ── Admin access ──────────────────────────────────────────────────────────────
 # Comma-separated list of Firebase Auth emails that have admin privileges.
-# Admin users automatically receive the $10 (tier3) plan and can access /admin.
+# Admin users automatically receive the Deck Master (tier3) plan and can access /admin.
 VITE_ADMIN_EMAILS=admin@example.com
 
 # Server-side copy — set this on the server host (e.g. Render dashboard) so the

--- a/e2e/tiers.spec.ts
+++ b/e2e/tiers.spec.ts
@@ -42,29 +42,30 @@ test.describe('Tier modal', () => {
     await openTierModal(page);
     const freeCard = page.locator('.tier-card').filter({ hasText: 'Free Rider' });
     await expect(
-      freeCard.locator('.tier-features li').filter({ hasText: /^✓ Create 1 free player card$/ }),
+      freeCard.locator('.tier-features li').filter({ hasText: /^✓ Create 1 starter player card$/ }),
     ).toBeVisible();
+    await expect(freeCard).toContainText(/1 free forge every 24 hours/i);
     await expect(freeCard).toContainText(/download or screenshot cards to share/i);
     await expect(freeCard).toContainText(/referral credits:/i);
     await expect(freeCard).not.toContainText(/share cards via link/i);
     await expect(freeCard).not.toContainText(/✓ 1 free player card/i);
   });
 
-  test('tier2 card shows $5 one-time price', async ({ page }) => {
+  test('tier2 card shows monthly subscription price', async ({ page }) => {
     await openTierModal(page);
     await expect(
       page.locator('.tier-card', {
         has: page.locator('.tier-name', { hasText: 'Street Creator' }),
       }).locator('.tier-price'),
-    ).toContainText('$5 one-time');
+    ).toContainText('$4.99/mo');
   });
 
-  test('tier3 card shows $10 one-time price and BEST VALUE badge', async ({ page }) => {
+  test('tier3 card shows monthly subscription price and BEST VALUE badge', async ({ page }) => {
     await openTierModal(page);
     const featuredCard = page.locator('.tier-card', {
       has: page.locator('.tier-name', { hasText: 'Deck Master' }),
     });
-    await expect(featuredCard.locator('.tier-price')).toContainText('$10 one-time');
+    await expect(featuredCard.locator('.tier-price')).toContainText('$9.99/mo');
     await expect(featuredCard.getByText('BEST VALUE')).toBeVisible();
   });
 
@@ -82,21 +83,21 @@ test.describe('Tier modal', () => {
 
   test('tier2 upgrade flow shows email input', async ({ page }) => {
     await openTierModal(page);
-    await page.getByRole('button', { name: /upgrade.*\$5/i }).click();
+    await page.getByRole('button', { name: /subscribe.*\$4\.99/i }).click();
     await expect(page.getByPlaceholder(/your@email\.com/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /continue to payment/i })).toBeVisible();
   });
 
   test('tier3 upgrade flow shows email input', async ({ page }) => {
     await openTierModal(page);
-    await page.getByRole('button', { name: /upgrade.*\$10/i }).click();
+    await page.getByRole('button', { name: /subscribe.*\$9\.99/i }).click();
     await expect(page.getByPlaceholder(/your@email\.com/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /continue to payment/i })).toBeVisible();
   });
 
   test('upgrade flow shows error for invalid email', async ({ page }) => {
     await openTierModal(page);
-    await page.getByRole('button', { name: /upgrade.*\$5/i }).click();
+    await page.getByRole('button', { name: /subscribe.*\$4\.99/i }).click();
     await page.getByPlaceholder(/your@email\.com/i).fill('not-an-email');
     await page.getByRole('button', { name: /continue to payment/i }).click();
     await expect(page.getByText(/valid email/i)).toBeVisible();
@@ -104,7 +105,7 @@ test.describe('Tier modal', () => {
 
   test('back button returns to tier list from email step', async ({ page }) => {
     await openTierModal(page);
-    await page.getByRole('button', { name: /upgrade.*\$5/i }).click();
+    await page.getByRole('button', { name: /subscribe.*\$4\.99/i }).click();
     await expect(page.getByRole('button', { name: /← back/i })).toBeVisible();
     await page.getByRole('button', { name: /← back/i }).click();
     await expect(page.locator('.tier-cards .tier-name', { hasText: 'Street Creator' })).toBeVisible();

--- a/server/index.js
+++ b/server/index.js
@@ -33,6 +33,7 @@ import {
 import {
   buildPurchasedTierUpdate,
   buildPendingPurchaseUpdate,
+  buildSubscriptionEntitlementUpdate,
   normalizePaidTier,
   resolveHigherPaidTier,
 } from './lib/payments.js';
@@ -273,13 +274,31 @@ const buildFalImageRequest = createFalImageRequestBuilder({
 // updating prices only requires editing that one file.
 const ALLOWED_PRICE_IDS = new Set(
   Object.values(tierPricing)
-    .map((t) => t.stripePriceId)
+    .flatMap((t) => [t.stripePriceId, t.stripeAnnualPriceId])
     .filter(Boolean),
 );
 
 function resolveTierFromPriceId(priceId) {
   for (const [tier, config] of Object.entries(tierPricing)) {
-    if (config.stripePriceId === priceId) return tier;
+    if (tier === 'seasonPass') continue;
+    if (config.stripePriceId === priceId || config.stripeAnnualPriceId === priceId) return tier;
+  }
+  return null;
+}
+
+function resolveCheckoutModeFromPriceId(priceId) {
+  for (const config of Object.values(tierPricing)) {
+    if (config.stripePriceId === priceId || config.stripeAnnualPriceId === priceId) {
+      return config.checkoutMode === 'subscription' ? 'subscription' : 'payment';
+    }
+  }
+  return null;
+}
+
+function resolveBillingPeriodFromPriceId(priceId) {
+  for (const config of Object.values(tierPricing)) {
+    if (config.stripeAnnualPriceId && config.stripeAnnualPriceId === priceId) return 'annual';
+    if (config.stripePriceId === priceId) return 'monthly';
   }
   return null;
 }
@@ -464,7 +483,17 @@ function pruneBoardImageJobs(now = Date.now()) {
   }
 }
 
-async function syncPurchasedTier({ tier, email, sessionId }) {
+async function syncPurchasedTier({
+  tier,
+  email,
+  sessionId,
+  checkoutMode,
+  stripeCustomerId,
+  stripeSubscriptionId,
+  subscriptionStatus,
+  currentPeriodEnd,
+  billingPeriod,
+}) {
   if (!adminDb) return;
   const normalizedTier = normalizePaidTier(tier);
   if (!normalizedTier) return;
@@ -495,6 +524,12 @@ async function syncPurchasedTier({ tier, email, sessionId }) {
       emailLower: normalizedEmail,
       tier: normalizedTier,
       sessionId,
+      checkoutMode,
+      stripeCustomerId,
+      stripeSubscriptionId,
+      subscriptionStatus,
+      currentPeriodEnd,
+      billingPeriod,
     }, FieldValue.serverTimestamp());
     if (pendingUpdate) {
       batch.set(pendingPurchaseRef, pendingUpdate, { merge: true });
@@ -508,6 +543,12 @@ async function syncPurchasedTier({ tier, email, sessionId }) {
       tier: normalizedTier,
       emailLower: normalizedEmail,
       sessionId,
+      checkoutMode,
+      stripeCustomerId,
+      stripeSubscriptionId,
+      subscriptionStatus,
+      currentPeriodEnd,
+      billingPeriod,
     }, FieldValue.serverTimestamp());
     if (!nextData) return;
     batch.set(docSnap.ref, nextData, { merge: true });
@@ -518,6 +559,12 @@ async function syncPurchasedTier({ tier, email, sessionId }) {
     emailLower: normalizedEmail,
     tier: normalizedTier,
     sessionId,
+    checkoutMode,
+    stripeCustomerId,
+    stripeSubscriptionId,
+    subscriptionStatus,
+    currentPeriodEnd,
+    billingPeriod,
   }, FieldValue.serverTimestamp());
   if (pendingUpdate) {
     batch.set(pendingPurchaseRef, pendingUpdate, { merge: true });
@@ -542,12 +589,38 @@ async function applyPendingPurchasedTierToProfile(uid, email) {
     tier: pendingPurchase?.tier,
     emailLower: normalizedEmail,
     sessionId: pendingPurchase?.lastCheckoutSessionId,
+    checkoutMode: pendingPurchase?.checkoutMode,
+    stripeCustomerId: pendingPurchase?.stripeCustomerId,
+    stripeSubscriptionId: pendingPurchase?.stripeSubscriptionId,
+    subscriptionStatus: pendingPurchase?.subscriptionStatus,
+    currentPeriodEnd: pendingPurchase?.currentPeriodEnd,
+    billingPeriod: pendingPurchase?.billingPeriod,
   }, FieldValue.serverTimestamp());
   if (!nextData) return;
 
   const batch = adminDb.batch();
   batch.set(adminDb.collection('userProfiles').doc(uid), nextData, { merge: true });
   batch.delete(pendingPurchaseRef);
+  await batch.commit();
+}
+
+async function syncSubscriptionEntitlement(subscription) {
+  if (!adminDb || !subscription?.stripeSubscriptionId) return;
+  const profileSnap = await adminDb.collection('userProfiles')
+    .where('stripeSubscriptionId', '==', subscription.stripeSubscriptionId)
+    .limit(25)
+    .get();
+  if (profileSnap.empty) return;
+
+  const batch = adminDb.batch();
+  profileSnap.docs.forEach((docSnap) => {
+    const nextData = buildSubscriptionEntitlementUpdate(
+      docSnap.data(),
+      subscription,
+      FieldValue.serverTimestamp(),
+    );
+    batch.set(docSnap.ref, nextData, { merge: true });
+  });
   await batch.commit();
 }
 
@@ -574,7 +647,10 @@ registerPaymentRoutes(app, {
   stripeWebhookSecret,
   checkoutRateLimit,
   resolveTierFromPriceId,
+  resolveCheckoutModeFromPriceId,
+  resolveBillingPeriodFromPriceId,
   syncPurchasedTier,
+  syncSubscriptionEntitlement,
   isAllowedRedirectUrl,
   normalizeEmail,
   timingSafeEmailMatches,

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -93,7 +93,9 @@ export function buildPendingPurchaseUpdate(currentData, purchase, updatedAt) {
   };
 
   if (shouldPersistPurchaseDetails(currentData?.tier, purchase?.tier)) {
-    addOptionalPurchaseFields(nextData, purchase);
+    if (purchase?.sessionId) {
+      nextData.lastCheckoutSessionId = purchase.sessionId;
+    }
   }
 
   return nextData;

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -3,6 +3,13 @@ const PAID_TIER_PRIORITY = {
   tier3: 2,
 };
 
+const SUBSCRIPTION_ACTIVE_STATUSES = new Set(['active', 'trialing']);
+
+const MONTHLY_FORGE_CREDITS = {
+  tier2: 50,
+  tier3: 150,
+};
+
 export function normalizePaidTier(value) {
   return value === 'tier2' || value === 'tier3' ? value : null;
 }
@@ -25,6 +32,36 @@ export function shouldPersistPurchaseDetails(currentTier, incomingTier) {
   return PAID_TIER_PRIORITY[normalizedIncoming] >= PAID_TIER_PRIORITY[normalizedCurrent];
 }
 
+export function resolveSubscriptionTier(status, tier) {
+  const normalizedTier = normalizePaidTier(tier);
+  if (!normalizedTier) return 'free';
+  return SUBSCRIPTION_ACTIVE_STATUSES.has(status) ? normalizedTier : 'free';
+}
+
+function addOptionalPurchaseFields(nextData, purchase) {
+  if (purchase?.emailLower) {
+    nextData.purchaseEmail = purchase.emailLower;
+  }
+  if (purchase?.sessionId) {
+    nextData.lastCheckoutSessionId = purchase.sessionId;
+  }
+  if (purchase?.stripeCustomerId) {
+    nextData.stripeCustomerId = purchase.stripeCustomerId;
+  }
+  if (purchase?.stripeSubscriptionId) {
+    nextData.stripeSubscriptionId = purchase.stripeSubscriptionId;
+  }
+  if (purchase?.subscriptionStatus) {
+    nextData.subscriptionStatus = purchase.subscriptionStatus;
+  }
+  if (purchase?.currentPeriodEnd) {
+    nextData.currentPeriodEnd = purchase.currentPeriodEnd;
+  }
+  if (purchase?.billingPeriod) {
+    nextData.billingPeriod = purchase.billingPeriod;
+  }
+}
+
 export function buildPurchasedTierUpdate(currentData, purchase, updatedAt) {
   const nextTier = resolveHigherPaidTier(currentData?.tier, purchase?.tier);
   if (!nextTier) return null;
@@ -35,11 +72,10 @@ export function buildPurchasedTierUpdate(currentData, purchase, updatedAt) {
   };
 
   if (shouldPersistPurchaseDetails(currentData?.tier, purchase?.tier)) {
-    if (purchase?.emailLower) {
-      nextData.purchaseEmail = purchase.emailLower;
-    }
-    if (purchase?.sessionId) {
-      nextData.lastCheckoutSessionId = purchase.sessionId;
+    addOptionalPurchaseFields(nextData, purchase);
+    if (purchase?.checkoutMode === 'subscription') {
+      nextData.monthlyForgeCreditsIncluded = MONTHLY_FORGE_CREDITS[nextTier] ?? null;
+      nextData.monthlyForgeCreditsRemaining = MONTHLY_FORGE_CREDITS[nextTier] ?? null;
     }
   }
 
@@ -56,9 +92,43 @@ export function buildPendingPurchaseUpdate(currentData, purchase, updatedAt) {
     updatedAt,
   };
 
-  if (shouldPersistPurchaseDetails(currentData?.tier, purchase?.tier) && purchase?.sessionId) {
-    nextData.lastCheckoutSessionId = purchase.sessionId;
+  if (shouldPersistPurchaseDetails(currentData?.tier, purchase?.tier)) {
+    addOptionalPurchaseFields(nextData, purchase);
   }
+
+  return nextData;
+}
+
+export function buildSubscriptionEntitlementUpdate(currentData, subscription, updatedAt) {
+  const desiredTier = resolveSubscriptionTier(subscription?.status, subscription?.tier);
+  const nextData = {
+    tier: desiredTier,
+    subscriptionStatus: subscription?.status ?? 'canceled',
+    updatedAt,
+  };
+
+  if (subscription?.stripeCustomerId) {
+    nextData.stripeCustomerId = subscription.stripeCustomerId;
+  }
+  if (subscription?.stripeSubscriptionId) {
+    nextData.stripeSubscriptionId = subscription.stripeSubscriptionId;
+  }
+  if (subscription?.currentPeriodEnd) {
+    nextData.currentPeriodEnd = subscription.currentPeriodEnd;
+  }
+  if (subscription?.billingPeriod) {
+    nextData.billingPeriod = subscription.billingPeriod;
+  }
+
+  if (desiredTier === 'free') {
+    nextData.monthlyForgeCreditsIncluded = 0;
+    nextData.monthlyForgeCreditsRemaining = 0;
+    return nextData;
+  }
+
+  const monthlyCredits = MONTHLY_FORGE_CREDITS[desiredTier] ?? 0;
+  nextData.monthlyForgeCreditsIncluded = monthlyCredits;
+  nextData.monthlyForgeCreditsRemaining = monthlyCredits;
 
   return nextData;
 }

--- a/server/routes/payments.js
+++ b/server/routes/payments.js
@@ -5,12 +5,27 @@ export function registerPaymentRoutes(app, {
   stripeWebhookSecret,
   checkoutRateLimit,
   resolveTierFromPriceId,
+  resolveCheckoutModeFromPriceId,
+  resolveBillingPeriodFromPriceId,
   syncPurchasedTier,
+  syncSubscriptionEntitlement,
   isAllowedRedirectUrl,
   normalizeEmail,
   timingSafeEmailMatches,
   sendCheckoutVerificationFailure,
 }) {
+  function timestampToIso(seconds) {
+    return Number.isFinite(seconds) && seconds > 0
+      ? new Date(seconds * 1000).toISOString()
+      : undefined;
+  }
+
+  function getStripeId(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    return typeof value.id === 'string' ? value.id : '';
+  }
+
   app.post('/api/stripe/webhook', express.raw({ type: 'application/json', limit: '256kb' }), async (req, res) => {
     if (!stripe || !stripeWebhookSecret) {
       res.status(503).json({ error: 'Stripe webhook handling is not configured.' });
@@ -36,10 +51,14 @@ export function registerPaymentRoutes(app, {
       if (event.type === 'checkout.session.completed') {
         const session = event.data.object;
         let paidTier = resolveTierFromPriceId(session.metadata?.priceId);
+        let checkoutMode = resolveCheckoutModeFromPriceId(session.metadata?.priceId);
+        let billingPeriod = resolveBillingPeriodFromPriceId(session.metadata?.priceId);
         if (!paidTier) {
           const lineItems = await stripe.checkout.sessions.listLineItems(session.id, { limit: 1 });
           const fallbackPriceId = lineItems.data[0]?.price?.id ?? '';
           paidTier = resolveTierFromPriceId(fallbackPriceId);
+          checkoutMode = resolveCheckoutModeFromPriceId(fallbackPriceId);
+          billingPeriod = resolveBillingPeriodFromPriceId(fallbackPriceId);
         }
         const customerEmail = typeof session.customer_details?.email === 'string'
           ? session.customer_details.email
@@ -47,10 +66,60 @@ export function registerPaymentRoutes(app, {
             ? session.customer_email
             : '';
         if (paidTier && session.payment_status === 'paid') {
+          let subscription = null;
+          const stripeSubscriptionId = getStripeId(session.subscription);
+          if (checkoutMode === 'subscription' && stripeSubscriptionId) {
+            subscription = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+          }
           await syncPurchasedTier({
             tier: paidTier,
             email: customerEmail,
             sessionId: session.id,
+            checkoutMode,
+            stripeCustomerId: getStripeId(session.customer),
+            stripeSubscriptionId,
+            subscriptionStatus: subscription?.status,
+            currentPeriodEnd: timestampToIso(subscription?.current_period_end),
+            billingPeriod,
+          });
+        }
+      } else if (
+        event.type === 'customer.subscription.updated' ||
+        event.type === 'customer.subscription.deleted'
+      ) {
+        const subscription = event.data.object;
+        const priceId = subscription.items?.data?.[0]?.price?.id ?? '';
+        const paidTier = resolveTierFromPriceId(priceId);
+        if (!paidTier) {
+          res.json({ received: true });
+          return;
+        }
+        await syncSubscriptionEntitlement({
+          tier: paidTier,
+          status: subscription.status,
+          stripeCustomerId: getStripeId(subscription.customer),
+          stripeSubscriptionId: subscription.id,
+          currentPeriodEnd: timestampToIso(subscription.current_period_end),
+          billingPeriod: resolveBillingPeriodFromPriceId(priceId),
+        });
+      } else if (event.type === 'invoice.paid') {
+        const invoice = event.data.object;
+        const stripeSubscriptionId = getStripeId(invoice.subscription);
+        if (stripeSubscriptionId) {
+          const subscription = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+          const priceId = subscription.items?.data?.[0]?.price?.id ?? '';
+          const paidTier = resolveTierFromPriceId(priceId);
+          if (!paidTier) {
+            res.json({ received: true });
+            return;
+          }
+          await syncSubscriptionEntitlement({
+            tier: paidTier,
+            status: subscription.status,
+            stripeCustomerId: getStripeId(subscription.customer),
+            stripeSubscriptionId: subscription.id,
+            currentPeriodEnd: timestampToIso(subscription.current_period_end),
+            billingPeriod: resolveBillingPeriodFromPriceId(priceId),
           });
         }
       }
@@ -71,9 +140,15 @@ export function registerPaymentRoutes(app, {
     const { priceId, successUrl, cancelUrl, email } = req.body ?? {};
     const normalizedEmail = normalizeEmail(email);
     const paidTier = resolveTierFromPriceId(priceId);
+    const checkoutMode = resolveCheckoutModeFromPriceId(priceId);
+    const billingPeriod = resolveBillingPeriodFromPriceId(priceId);
 
-    if (!priceId || typeof priceId !== 'string' || !paidTier) {
+    if (!priceId || typeof priceId !== 'string' || !paidTier || !checkoutMode) {
       res.status(400).json({ error: 'Invalid or unsupported price ID.' });
+      return;
+    }
+    if (!billingPeriod) {
+      res.status(400).json({ error: 'Billing period is not configured for this price ID.' });
       return;
     }
 
@@ -85,13 +160,18 @@ export function registerPaymentRoutes(app, {
     try {
       const session = await stripe.checkout.sessions.create({
         line_items: [{ price: priceId, quantity: 1 }],
-        mode: 'payment',
+        mode: checkoutMode,
+        ...(checkoutMode === 'subscription'
+          ? { subscription_data: { metadata: { priceId, paidTier, billingPeriod } } }
+          : {}),
         ...(typeof email === 'string' && email.trim()
           ? { customer_email: email.trim() }
           : {}),
         metadata: {
           priceId,
           paidTier,
+          checkoutMode,
+          billingPeriod,
           ...(normalizedEmail ? { emailLower: normalizedEmail } : {}),
         },
         success_url: successUrl,
@@ -126,6 +206,8 @@ export function registerPaymentRoutes(app, {
       const lineItems = await stripe.checkout.sessions.listLineItems(sessionId, { limit: 1 });
       const priceId = lineItems.data[0]?.price?.id;
       const paidTier = resolveTierFromPriceId(priceId);
+      const checkoutMode = resolveCheckoutModeFromPriceId(priceId);
+      const billingPeriod = resolveBillingPeriodFromPriceId(priceId);
       const sessionEmail = (session.customer_details?.email ?? session.customer_email ?? '').trim().toLowerCase();
 
       if (
@@ -146,10 +228,21 @@ export function registerPaymentRoutes(app, {
         return;
       }
 
+      let subscription = null;
+      const stripeSubscriptionId = getStripeId(session.subscription);
+      if (checkoutMode === 'subscription' && stripeSubscriptionId) {
+        subscription = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+      }
       await syncPurchasedTier({
         tier: paidTier,
         email: sessionEmail,
         sessionId,
+        checkoutMode,
+        stripeCustomerId: getStripeId(session.customer),
+        stripeSubscriptionId,
+        subscriptionStatus: subscription?.status,
+        currentPeriodEnd: timestampToIso(subscription?.current_period_end),
+        billingPeriod,
       });
       res.json({
         tier: paidTier,

--- a/server/test/payments.test.js
+++ b/server/test/payments.test.js
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict';
 import {
   buildPendingPurchaseUpdate,
   buildPurchasedTierUpdate,
+  buildSubscriptionEntitlementUpdate,
   normalizePaidTier,
   resolveHigherPaidTier,
+  resolveSubscriptionTier,
   shouldPersistPurchaseDetails,
 } from '../lib/payments.js';
 
@@ -90,6 +92,64 @@ test('buildPendingPurchaseUpdate stores session metadata for new or upgraded pur
     emailLower: 'buyer@example.com',
     tier: 'tier2',
     lastCheckoutSessionId: 'cs_pending',
+    updatedAt: 'timestamp',
+  });
+});
+
+test('buildPurchasedTierUpdate stores subscription entitlement metadata and credits', () => {
+  const update = buildPurchasedTierUpdate({}, {
+    tier: 'tier3',
+    emailLower: 'buyer@example.com',
+    sessionId: 'cs_subscribe',
+    checkoutMode: 'subscription',
+    stripeCustomerId: 'cus_123',
+    stripeSubscriptionId: 'sub_123',
+    subscriptionStatus: 'active',
+    currentPeriodEnd: '2026-06-01T00:00:00.000Z',
+    billingPeriod: 'monthly',
+  }, 'timestamp');
+
+  assert.deepEqual(update, {
+    tier: 'tier3',
+    purchaseEmail: 'buyer@example.com',
+    lastCheckoutSessionId: 'cs_subscribe',
+    stripeCustomerId: 'cus_123',
+    stripeSubscriptionId: 'sub_123',
+    subscriptionStatus: 'active',
+    currentPeriodEnd: '2026-06-01T00:00:00.000Z',
+    billingPeriod: 'monthly',
+    monthlyForgeCreditsIncluded: 150,
+    monthlyForgeCreditsRemaining: 150,
+    updatedAt: 'timestamp',
+  });
+});
+
+test('resolveSubscriptionTier only grants active or trialing subscriptions', () => {
+  assert.equal(resolveSubscriptionTier('active', 'tier2'), 'tier2');
+  assert.equal(resolveSubscriptionTier('trialing', 'tier3'), 'tier3');
+  assert.equal(resolveSubscriptionTier('past_due', 'tier3'), 'free');
+  assert.equal(resolveSubscriptionTier('canceled', 'tier2'), 'free');
+});
+
+test('buildSubscriptionEntitlementUpdate downgrades canceled subscriptions', () => {
+  const update = buildSubscriptionEntitlementUpdate({
+    tier: 'tier3',
+  }, {
+    tier: 'tier3',
+    status: 'canceled',
+    stripeCustomerId: 'cus_123',
+    stripeSubscriptionId: 'sub_123',
+    currentPeriodEnd: '2026-06-01T00:00:00.000Z',
+  }, 'timestamp');
+
+  assert.deepEqual(update, {
+    tier: 'free',
+    subscriptionStatus: 'canceled',
+    stripeCustomerId: 'cus_123',
+    stripeSubscriptionId: 'sub_123',
+    currentPeriodEnd: '2026-06-01T00:00:00.000Z',
+    monthlyForgeCreditsIncluded: 0,
+    monthlyForgeCreditsRemaining: 0,
     updatedAt: 'timestamp',
   });
 });

--- a/src/components/TierModal.tsx
+++ b/src/components/TierModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { TIERS, saveEmail, type TierLevel } from "../lib/tiers";
+import { SEASON_PASS, TIERS, saveEmail, type PaidBillingPeriod, type TierLevel } from "../lib/tiers";
 import { useTier } from "../context/TierContext";
 import { resolveApiUrl } from "../lib/apiUrls";
 import { ReferralPanel } from "./ReferralPanel";
@@ -17,6 +17,7 @@ export function TierModal({ onClose }: TierModalProps) {
   const { tier, email, setTier } = useTier();
   const [signupEmail, setSignupEmail] = useState(email);
   const [signupStep, setSignupStep] = useState<TierLevel | null>(null);
+  const [billingPeriod, setBillingPeriod] = useState<PaidBillingPeriod>("monthly");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -38,7 +39,13 @@ export function TierModal({ onClose }: TierModalProps) {
       return;
     }
     const tierData = TIERS[signupStep];
-    if (!tierData.stripePriceId) return;
+    const selectedPriceId = billingPeriod === "annual"
+      ? tierData.stripeAnnualPriceId
+      : tierData.stripePriceId;
+    if (!selectedPriceId) {
+      setError("This billing option is not configured yet.");
+      return;
+    }
 
     // Store email so it's available after Stripe redirect
     saveEmail(emailVal);
@@ -57,7 +64,7 @@ export function TierModal({ onClose }: TierModalProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: emailVal,
-          priceId: tierData.stripePriceId,
+          priceId: selectedPriceId,
           successUrl,
           cancelUrl,
         }),
@@ -83,7 +90,7 @@ export function TierModal({ onClose }: TierModalProps) {
       <div className="modal-panel" onClick={(e) => e.stopPropagation()}>
         <button className="close-btn modal-close" onClick={onClose}>✕</button>
         <h2 className="modal-title">Choose Your Tier</h2>
-        <p className="modal-sub">Pick the access level that fits your style.</p>
+        <p className="modal-sub">Subscribe for forge credits, collection tools, and cosmetics. Gameplay power still comes from play.</p>
 
         {!signupStep ? (
           <div className="tier-cards">
@@ -98,6 +105,7 @@ export function TierModal({ onClose }: TierModalProps) {
                   {lvl === "tier3" && <span className="tier-badge">BEST VALUE</span>}
                   <div className="tier-name">{t.name}</div>
                   <div className="tier-price">{t.price}</div>
+                  {t.annualPrice && <div className="tier-annual-price">{t.annualPrice}</div>}
                    <p className="tier-desc">{t.description}</p>
                    <ul className="tier-features">
                      {t.features.map((f) => (
@@ -116,19 +124,54 @@ export function TierModal({ onClose }: TierModalProps) {
                      onClick={() => handleSelectTier(lvl)}
                      disabled={isCurrent}
                    >
-                    {isCurrent ? "Current Plan" : lvl === "free" ? "Use Free" : `Upgrade — ${t.price}`}
+                    {isCurrent ? "Current Plan" : lvl === "free" ? "Use Free" : `Subscribe — ${t.price}`}
                   </button>
                 </div>
               );
             })}
+            <div className="tier-card tier-card--season">
+              <div className="tier-name">{SEASON_PASS.name}</div>
+              <div className="tier-price">{SEASON_PASS.price}</div>
+              <p className="tier-desc">{SEASON_PASS.description}</p>
+              <ul className="tier-features">
+                {SEASON_PASS.features.map((f) => (
+                  <li key={f}>✓ {f}</li>
+                ))}
+              </ul>
+              <button
+                className="btn-outline tier-select-btn"
+                type="button"
+                disabled={!SEASON_PASS.stripePriceId}
+                onClick={() => setError("Season Pass checkout will be enabled after its Stripe price is configured.")}
+              >
+                {SEASON_PASS.stripePriceId ? `Buy — ${SEASON_PASS.price}` : "Coming Soon"}
+              </button>
+            </div>
           </div>
         ) : (
           <div className="tier-signup">
             <button className="btn-outline tier-back" onClick={() => setSignupStep(null)}>← Back</button>
             <h3 className="tier-signup-title">Sign up for {TIERS[signupStep].name}</h3>
             <p className="tier-signup-desc">
-              Enter your email to link your purchase. After payment you'll be redirected back with your tier activated.
+              Enter your email to link your subscription. After payment you'll be redirected back with your tier activated.
             </p>
+            <div className="tier-billing-toggle" role="group" aria-label="Billing period">
+              <button
+                type="button"
+                className={`btn-outline btn-sm${billingPeriod === "monthly" ? " tier-billing-toggle--active" : ""}`}
+                onClick={() => setBillingPeriod("monthly")}
+              >
+                Monthly · {TIERS[signupStep].price}
+              </button>
+              <button
+                type="button"
+                className={`btn-outline btn-sm${billingPeriod === "annual" ? " tier-billing-toggle--active" : ""}`}
+                onClick={() => setBillingPeriod("annual")}
+                disabled={!TIERS[signupStep].stripeAnnualPriceId}
+              >
+                Annual · {TIERS[signupStep].annualPrice ?? "Coming Soon"}
+              </button>
+            </div>
             <input
               className="input"
               type="email"
@@ -139,7 +182,9 @@ export function TierModal({ onClose }: TierModalProps) {
             />
             {error && <p className="tier-error">{error}</p>}
             <button className="btn-primary btn-lg" onClick={handleProceedToPayment} disabled={loading}>
-              {loading ? "Redirecting to payment…" : `Continue to Payment — ${TIERS[signupStep].price}`}
+              {loading ? "Redirecting to payment…" : `Continue to Payment — ${
+                billingPeriod === "annual" ? TIERS[signupStep].annualPrice ?? TIERS[signupStep].price : TIERS[signupStep].price
+              }`}
             </button>
           </div>
         )}

--- a/src/hooks/useBattlePass.ts
+++ b/src/hooks/useBattlePass.ts
@@ -12,6 +12,7 @@ import {
   type LocalBattlePassState,
 } from "../lib/battlePass";
 import { isEnabled } from "../lib/featureFlags";
+import { useTier } from "../context/TierContext";
 
 export interface BattlePassHookState {
   enabled: boolean;
@@ -32,11 +33,16 @@ export interface BattlePassHookState {
 
 export function useBattlePass(): BattlePassHookState {
   const enabled = isEnabled("BATTLE_PASS");
+  const { tier } = useTier();
   const [state, setState] = useState<LocalBattlePassState>(loadBattlePassState);
 
   const seasonId = getCurrentSeasonId();
   const bounds = useMemo(() => getSeasonBounds(seasonId), [seasonId]);
-  const xpProgress = useMemo(() => getXpProgress(state), [state]);
+  const effectiveState = useMemo(
+    () => (tier === "tier3" ? { ...state, isPremium: true } : state),
+    [state, tier],
+  );
+  const xpProgress = useMemo(() => getXpProgress(effectiveState), [effectiveState]);
 
   const addXp = useCallback((amount: number) => {
     setState((prev) => addXpToPass(prev, amount));
@@ -47,8 +53,12 @@ export function useBattlePass(): BattlePassHookState {
   }, []);
 
   const claimPremiumReward = useCallback((tier: number) => {
-    setState((prev) => claimReward(prev, tier, true));
-  }, []);
+    setState((prev) => claimReward(
+      tier === "tier3" ? { ...prev, isPremium: true } : prev,
+      tier,
+      true,
+    ));
+  }, [tier]);
 
   const isRewardClaimed = useCallback(
     (tier: number, premium: boolean) => {
@@ -61,22 +71,22 @@ export function useBattlePass(): BattlePassHookState {
 
   const isRewardAvailable = useCallback(
     (tier: number, premium: boolean) => {
-      if (tier > state.tier) return false;
-      if (premium && !state.isPremium) return false;
+      if (tier > effectiveState.tier) return false;
+      if (premium && !effectiveState.isPremium) return false;
       return !(premium
-        ? state.claimedPremiumRewards.includes(tier)
-        : state.claimedFreeRewards.includes(tier));
+        ? effectiveState.claimedPremiumRewards.includes(tier)
+        : effectiveState.claimedFreeRewards.includes(tier));
     },
-    [state],
+    [effectiveState],
   );
 
   return {
     enabled,
-    state,
+    state: effectiveState,
     seasonId,
     seasonName: `Season ${seasonId}`,
     seasonEndsAt: bounds.endsAt,
-    tier: state.tier,
+    tier: effectiveState.tier,
     maxTier: BATTLE_PASS_MAX_TIER,
     xpProgress,
     tiers: BATTLE_PASS_TIERS,

--- a/src/index.css
+++ b/src/index.css
@@ -2409,7 +2409,7 @@ button { cursor: pointer; font-family: var(--font); transition: all 0.2s ease; }
 /* ===== Tier Cards (inside modal) ===== */
 .tier-cards {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
 }
 @media (max-width: 680px) { .tier-cards { grid-template-columns: 1fr; } }
@@ -2426,6 +2426,7 @@ button { cursor: pointer; font-family: var(--font); transition: all 0.2s ease; }
 }
 .tier-card--active { border-color: var(--accent2); }
 .tier-card--featured { border-color: var(--purple); }
+.tier-card--season { border-color: rgba(255, 204, 0, 0.42); }
 
 .tier-badge {
   position: absolute;
@@ -2443,6 +2444,7 @@ button { cursor: pointer; font-family: var(--font); transition: all 0.2s ease; }
 
 .tier-name { font-size: 15px; font-weight: bold; color: var(--text); letter-spacing: 1px; }
 .tier-price { font-size: 18px; color: var(--accent); font-weight: bold; margin-bottom: 4px; }
+.tier-annual-price { font-size: 12px; color: var(--text-dim); margin-top: -4px; }
 .tier-desc { font-size: 12px; color: var(--text-dim); line-height: 1.5; }
 
 .tier-features {
@@ -2479,6 +2481,8 @@ button { cursor: pointer; font-family: var(--font); transition: all 0.2s ease; }
 .tier-back { align-self: flex-start; font-size: 12px; }
 .tier-signup-title { font-size: 16px; color: var(--accent); letter-spacing: 1px; }
 .tier-signup-desc { font-size: 12px; color: var(--text-dim); line-height: 1.6; }
+.tier-billing-toggle { display: flex; gap: 8px; flex-wrap: wrap; }
+.tier-billing-toggle--active { border-color: var(--accent); color: var(--accent); }
 .tier-error { font-size: 12px; color: var(--danger); }
 
 /* ===== Share Modal ===== */

--- a/src/lib/dailyRewards.ts
+++ b/src/lib/dailyRewards.ts
@@ -1,5 +1,5 @@
 export const DAILY_REWARD_STREAK_CAP = 7;
-export const FREE_FORGE_COOLDOWN_MS = 8 * 60 * 60 * 1000;
+export const FREE_FORGE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 export interface DailyRewardAmounts {
   xp: number;

--- a/src/lib/tierPricing.json
+++ b/src/lib/tierPricing.json
@@ -1,12 +1,24 @@
 {
   "tier2": {
-    "price": "$5 one-time",
+    "price": "$4.99/mo",
+    "annualPrice": "$39/year",
+    "checkoutMode": "subscription",
     "stripePriceId": "price_1TJOKHRCr5JxQN06wMYFHTm5",
+    "stripeAnnualPriceId": "",
     "stripeUrl": "https://buy.stripe.com/4gW2bUeLCceFa3x8M2"
   },
   "tier3": {
-    "price": "$10 one-time",
+    "price": "$9.99/mo",
+    "annualPrice": "$79/year",
+    "checkoutMode": "subscription",
     "stripePriceId": "price_1TJOKrRCr5JxQN06RyDF02bi",
+    "stripeAnnualPriceId": "",
     "stripeUrl": "https://buy.stripe.com/cNi5kF3XOcFA4DH1w25ZC01"
+  },
+  "seasonPass": {
+    "price": "$4.99 / season",
+    "checkoutMode": "payment",
+    "stripePriceId": "",
+    "stripeUrl": ""
   }
 }

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -7,17 +7,22 @@ import tierPricingRaw from "./tierPricing.json";
 
 interface TierPricingEntry {
   price: string;
+  annualPrice?: string;
+  checkoutMode: "payment" | "subscription";
   stripePriceId: string;
+  stripeAnnualPriceId?: string;
   stripeUrl: string;
 }
-const tierPricing = tierPricingRaw as Record<"tier2" | "tier3", TierPricingEntry>;
+const tierPricing = tierPricingRaw as Record<"tier2" | "tier3" | "seasonPass", TierPricingEntry>;
 
 export type TierLevel = "free" | "tier2" | "tier3";
+export type PaidBillingPeriod = "monthly" | "annual";
 
 export interface Tier {
   level: TierLevel;
   name: string;
   price: string;
+  annualPrice?: string;
   cardLimit: number | null;
   canSave: boolean;
   canEditDecks: boolean;
@@ -27,12 +32,33 @@ export interface Tier {
   canUseCraftlingua: boolean;
   /** Maximum number of decks this tier may own (null = unlimited). */
   maxDecks: number | null;
+  /** Monthly forge credits granted by the paid plan (null = not credit-limited in the current client). */
+  monthlyForgeCredits: number | null;
   description: string;
   features: string[];
   stripeUrl: string | null;
-  /** Stripe Price ID used to create a Checkout Session for this tier. */
+  /** Stripe Price ID used to create a Checkout Session for the monthly tier. */
   stripePriceId: string | null;
+  /** Stripe Price ID used to create a Checkout Session for the annual tier. */
+  stripeAnnualPriceId?: string | null;
+  checkoutMode: "payment" | "subscription" | null;
 }
+
+export const SEASON_PASS = {
+  level: "seasonPass",
+  name: "Season Pass",
+  price: tierPricing.seasonPass.price,
+  description: "Premium 6-week Battle Pass track for cosmetics, titles, frames, and modest forge-credit rewards.",
+  features: [
+    "Premium Battle Pass reward track",
+    "Season-exclusive frames and titles",
+    "Cosmetic-first rewards with no pay-to-win stat boosts",
+    "Included with Deck Master while subscribed",
+  ],
+  stripePriceId: tierPricing.seasonPass.stripePriceId || null,
+  stripeUrl: tierPricing.seasonPass.stripeUrl || null,
+  checkoutMode: tierPricing.seasonPass.checkoutMode,
+} as const;
 
 export const TIERS: Record<TierLevel, Tier> = {
   free: {
@@ -45,9 +71,11 @@ export const TIERS: Record<TierLevel, Tier> = {
     canGenerate: false,
     canUseCraftlingua: false,
     maxDecks: 0,
-    description: "Explore the app — create 1 free card, then upgrade or earn referral credits to forge more.",
+    monthlyForgeCredits: null,
+    description: "Explore the app — forge a starter card, then use your free daily forge or referral credits.",
     features: [
-      "Create 1 free player card",
+      "Create 1 starter player card",
+      "1 free forge every 24 hours",
       "Browse the app",
       "Download or screenshot cards to share",
       "Earn extra generate credits via referrals",
@@ -55,49 +83,61 @@ export const TIERS: Record<TierLevel, Tier> = {
     ],
     stripeUrl: null,
     stripePriceId: null,
+    checkoutMode: null,
   },
   tier2: {
     level: "tier2",
     name: "Street Creator",
     price: tierPricing.tier2.price,
-    cardLimit: 18,
+    annualPrice: tierPricing.tier2.annualPrice,
+    cardLimit: 50,
     canSave: true,
-    canEditDecks: false,
+    canEditDecks: true,
     canGenerate: true,
     canUseCraftlingua: true,
-    maxDecks: 1,
-    description: "Sign up and save up to 18 cards in your Collection.",
+    maxDecks: 3,
+    monthlyForgeCredits: 50,
+    description: "A monthly creator plan for casual collectors: cloud saves, crews, trading, and a healthy forge-credit allowance.",
     features: [
       "Everything in Free",
-      "Account & card saving",
-      "Collection of up to 18 cards",
-      "One deck (add from Collection)",
+      "50 forge credits per month",
+      "Cloud Collection of up to 50 cards",
+      "Build up to 3 crews/decks",
+      "Basic card editing and trading",
       "Export your collection",
       "CraftLingua language profiles",
     ],
     stripeUrl: tierPricing.tier2.stripeUrl,
     stripePriceId: tierPricing.tier2.stripePriceId,
+    stripeAnnualPriceId: tierPricing.tier2.stripeAnnualPriceId || null,
+    checkoutMode: tierPricing.tier2.checkoutMode,
   },
   tier3: {
     level: "tier3",
     name: "Deck Master",
     price: tierPricing.tier3.price,
-    cardLimit: 100,
+    annualPrice: tierPricing.tier3.annualPrice,
+    cardLimit: 250,
     canSave: true,
     canEditDecks: true,
     canGenerate: true,
     canUseCraftlingua: true,
     maxDecks: null,
-    description: "Full access — 100-card Collection, multiple decks, edit all cards.",
+    monthlyForgeCredits: 150,
+    description: "Premium monthly access for serious players: bigger collection, unlimited crews, premium cosmetics, and Season Pass included.",
     features: [
       "Everything in Street Creator",
-      "Collection of up to 100 cards",
-      "Multiple decks (add from Collection)",
-      "Edit & delete any card",
-      "CraftLingua language profiles",
+      "150 forge credits per month",
+      "Cloud Collection of up to 250 cards",
+      "Unlimited crews/decks",
+      "Full edit, delete, print, and export tools",
+      "Premium Battle Pass included",
+      "Premium cosmetics and CraftLingua profiles",
     ],
     stripeUrl: tierPricing.tier3.stripeUrl,
     stripePriceId: tierPricing.tier3.stripePriceId,
+    stripeAnnualPriceId: tierPricing.tier3.stripeAnnualPriceId || null,
+    checkoutMode: tierPricing.tier3.checkoutMode,
   },
 };
 

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -41,9 +41,11 @@ export function TermsOfService() {
       <section className="credits-section">
         <h2 className="credits-heading">Paid Tiers</h2>
         <p className="legal-body">
-          Punch Skater offers optional paid tiers (Street Creator and Deck Master) that unlock
-          additional features. Payments are processed by Stripe and are subject to Stripe's terms.
-          All purchases are final. See the Refund Policy section below.
+          Punch Skater offers optional subscriptions (Street Creator and Deck Master) and seasonal
+          digital passes that unlock creator tools, collection capacity, cosmetic rewards, and
+          forge-credit allowances. Payments are processed by Stripe and are subject to Stripe's
+          terms. Subscription access remains available while the subscription is active. All
+          purchases are final. See the Refund Policy section below.
         </p>
       </section>
 

--- a/src/pages/cardForge/ForgeControlsPanel.tsx
+++ b/src/pages/cardForge/ForgeControlsPanel.tsx
@@ -365,7 +365,7 @@ export function ForgeControlsPanel({
           {freeForgeRemainingMs > 0
             ? `Your next free forge unlocks in ${formatDurationClock(freeForgeRemainingMs)}.`
             : freeCardUsed
-              ? "Your 8-hour free forge is ready."
+              ? "Your daily free forge is ready."
               : "Your first free forge is ready right now."}
         </p>
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Convert tier pricing and UI copy from one-time purchases to Free Rider, Street Creator, Deck Master, and Season Pass package messaging
- Add subscription-aware Stripe checkout mode resolution, subscription metadata persistence, lifecycle webhook handling, and monthly forge credit entitlements
- Include Deck Master premium Battle Pass access, 24-hour free forge cadence, updated tests/copy, and tier card styling for the added Season Pass card

## Verification
- `git diff --check` passed
- Targeted stale pricing/payment-mode searches passed
- `npm run test:server` and `npm run build` could not run because this cloud image does not have Node/npm installed on PATH
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-852f7ace-fa6b-42b1-a771-36413c122f5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-852f7ace-fa6b-42b1-a771-36413c122f5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

