### PR TITLE
Fix sitewide errors and security vulnerabilities

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,28 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
+    // Email fields written by clients must match the verified Firebase Auth
+    // token. Otherwise a player could claim another player's email and hijack
+    // Stripe purchase syncs or trade-recipient lookups keyed by emailLower.
+    function authEmail() {
+      return ('email' in request.auth.token) ? request.auth.token.email : '';
+    }
+
+    function writesVerifiedEmail() {
+      return request.resource.data.get('email', '') == authEmail();
+    }
+
+    function writesVerifiedEmailLower() {
+      return request.resource.data.get('emailLower', '') == authEmail().lower();
+    }
+
+    function keepsOrVerifiesEmailFields() {
+      return (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['email'])
+          || writesVerifiedEmail())
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['emailLower'])
+          || writesVerifiedEmailLower());
+    }
+
     // ── Per-user cards ───────────────────────────────────────────────────────
     match /users/{uid}/cards/{cardId} {
       allow read, write: if request.auth != null
@@ -39,33 +61,41 @@ service cloud.firestore {
         (request.auth.uid == uid
           && request.resource.data.keys().hasOnly([
             'uid', 'email', 'emailLower', 'displayName', 'discoveredFactions', 'updatedAt'
-          ]))
+          ])
+          && writesVerifiedEmail()
+          && writesVerifiedEmailLower())
         || request.auth.token.admin == true
       );
       allow update: if request.auth != null && (
         (request.auth.uid == uid
           && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
             'email', 'emailLower', 'displayName', 'discoveredFactions', 'updatedAt'
-          ]))
+          ])
+          && keepsOrVerifiesEmailFields())
         || request.auth.token.admin == true
       );
       allow delete: if request.auth != null && request.auth.token.admin == true;
     }
 
     // ── Public user lookup (trade/address book) ──────────────────────────────
-    // Minimal directory used for recipient lookup during trades.
+    // Minimal directory used for recipient lookup during trades. Individual
+    // docs may be fetched by ID, but listing is blocked so the collection
+    // cannot be scraped as a sitewide email directory.
     match /userLookup/{uid} {
-      allow read: if request.auth != null;
+      allow get: if request.auth != null;
+      allow list: if request.auth != null && request.auth.token.admin == true;
       allow create: if request.auth != null && (
         (request.auth.uid == uid
-          && request.resource.data.keys().hasOnly(['uid', 'emailLower', 'displayName', 'updatedAt']))
+          && request.resource.data.keys().hasOnly(['uid', 'emailLower', 'displayName', 'updatedAt'])
+          && writesVerifiedEmailLower())
         || request.auth.token.admin == true
       );
       allow update: if request.auth != null && (
         (request.auth.uid == uid
           && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
             'emailLower', 'displayName', 'updatedAt'
-          ]))
+          ])
+          && keepsOrVerifiesEmailFields())
         || request.auth.token.admin == true
       );
       allow delete: if request.auth != null && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -5281,9 +5281,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "gh-pages": "^6.2.0",
         "globals": "^15.11.0",
         "sharp": "^0.34.4",
-        "typescript": "~5.6.2",
+        "typescript": "~5.8.3",
         "typescript-eslint": "^8.11.0",
         "vite": "^6.4.2",
         "vite-plugin-pwa": "^0.21.1"
@@ -11491,9 +11491,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deploy": "gh-pages -d dist",
     "start": "node server/index.js",
     "optimize:assets": "node scripts/optimize-assets.mjs",
-    "test:server": "node --test server/test/*.test.js",
+    "test:server": "node --experimental-strip-types --test server/test/*.test.js",
     "test:e2e": "playwright test",
     "test:e2e:report": "playwright show-report"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gh-pages": "^6.2.0",
     "globals": "^15.11.0",
     "sharp": "^0.34.4",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.3",
     "typescript-eslint": "^8.11.0",
     "vite": "^6.4.2",
     "vite-plugin-pwa": "^0.21.1"

--- a/public/classic-race/boot.js
+++ b/public/classic-race/boot.js
@@ -7,11 +7,10 @@ const PHASER_CANDIDATES = [
 function showLoadError(message) {
   const container = document.getElementById('game-container');
   if (!container) return;
-  container.innerHTML = `
-    <div class="fallback fallback--centered">
-      ${message}
-    </div>
-  `;
+  const fallback = document.createElement('div');
+  fallback.className = 'fallback fallback--centered';
+  fallback.textContent = message;
+  container.replaceChildren(fallback);
 }
 
 async function loadPhaser() {

--- a/server/battle.js
+++ b/server/battle.js
@@ -1,8 +1,29 @@
 const MIN_SINGLE_STAT = 1;
 const MAX_SINGLE_STAT = 10;
+// Older saved cards used a 1–200 stat scale; mirror the client's
+// normalizeLegacyCardStat so legacy decks resolve the same everywhere.
+const LEGACY_MAX_SINGLE_STAT = 200;
 const WAGER_POINTS = 6;
 const WINNER_BONUS = WAGER_POINTS * 2;
 const STAT_KEYS = ["speed", "stealth", "tech", "grit", "rep"];
+
+function clampCardStat(value) {
+  return Math.max(MIN_SINGLE_STAT, Math.min(MAX_SINGLE_STAT, Math.round(value)));
+}
+
+// Card docs and deck snapshots are client-writable per firestore.rules, so a
+// hostile payload can carry arbitrary stat values. Normalize every stat onto
+// the live 1–10 scale before battle resolution instead of trusting the client.
+export function normalizeBattleCardStat(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return MIN_SINGLE_STAT;
+  if (num <= MAX_SINGLE_STAT) return clampCardStat(num);
+
+  const scaled = MIN_SINGLE_STAT
+    + ((Math.min(num, LEGACY_MAX_SINGLE_STAT) - MIN_SINGLE_STAT) * (MAX_SINGLE_STAT - MIN_SINGLE_STAT))
+      / (LEGACY_MAX_SINGLE_STAT - MIN_SINGLE_STAT);
+  return clampCardStat(scaled);
+}
 
 function seedFromString(seed) {
   let hash = 2166136261;
@@ -113,11 +134,11 @@ export function createBattleCardSnapshot(card) {
     id: card.id,
     archetype: card.prompts?.archetype ?? card.archetype,
     stats: {
-      speed: Number(card.stats?.speed ?? MIN_SINGLE_STAT),
-      stealth: Number(card.stats?.stealth ?? MIN_SINGLE_STAT),
-      tech: Number(card.stats?.tech ?? MIN_SINGLE_STAT),
-      grit: Number(card.stats?.grit ?? MIN_SINGLE_STAT),
-      rep: Number(card.stats?.rep ?? MIN_SINGLE_STAT),
+      speed: normalizeBattleCardStat(card.stats?.speed ?? MIN_SINGLE_STAT),
+      stealth: normalizeBattleCardStat(card.stats?.stealth ?? MIN_SINGLE_STAT),
+      tech: normalizeBattleCardStat(card.stats?.tech ?? MIN_SINGLE_STAT),
+      grit: normalizeBattleCardStat(card.stats?.grit ?? MIN_SINGLE_STAT),
+      rep: normalizeBattleCardStat(card.stats?.rep ?? MIN_SINGLE_STAT),
     },
   };
 }

--- a/server/index.js
+++ b/server/index.js
@@ -165,6 +165,9 @@ const imageRateLimit = buildRateLimiter({
   max: 20,
   message: { error: 'Too many image requests — please wait a moment and try again.' },
   store: sharedRateLimitStore,
+  // Image generation spends real Fal.ai budget — fail closed rather than
+  // becoming unlimited if the Redis rate-limit store errors out.
+  passOnStoreError: false,
 });
 
 // Status-check polling is cheap (no AI inference), so allow a higher burst.
@@ -294,6 +297,15 @@ const craftlinguaRateLimit = buildRateLimiter({
   windowMs: 60 * 1000,
   max: 60,
   message: { error: 'Too many CraftLingua requests — please slow down.' },
+  store: sharedRateLimitStore,
+});
+
+// The hype face-off endpoint is unauthenticated and backed by Firestore reads,
+// so rate-limit it to keep scrapers from hammering the Admin SDK.
+const hypeRateLimit = buildRateLimiter({
+  windowMs: 60 * 1000,
+  max: 30,
+  message: { error: 'Too many hype requests — please wait a moment and try again.' },
   store: sharedRateLimitStore,
 });
 
@@ -902,6 +914,7 @@ registerWeatherRoutes(app, {
 
 registerHypeRoutes(app, {
   adminDb,
+  hypeRateLimit,
 });
 
 registerCraftlinguaRoutes(app, {

--- a/server/lib/rateLimit.js
+++ b/server/lib/rateLimit.js
@@ -30,7 +30,10 @@ export function shouldSkipRateLimitRequest(req) {
   return req?.method === 'OPTIONS';
 }
 
-export function buildRateLimiter({ windowMs, max, message, store }) {
+// passOnStoreError defaults to true so a Redis outage does not take down the
+// whole API. Expensive endpoints (paid AI inference) should pass false so they
+// fail closed instead of becoming unlimited while the store is unavailable.
+export function buildRateLimiter({ windowMs, max, message, store, passOnStoreError = true }) {
   return rateLimit({
     windowMs,
     max,
@@ -38,7 +41,7 @@ export function buildRateLimiter({ windowMs, max, message, store }) {
     standardHeaders: 'draft-8',
     legacyHeaders: false,
     message,
-    passOnStoreError: true,
+    passOnStoreError,
     ...(store ? { store } : {}),
   });
 }

--- a/server/lib/seasonalLeaderboard.js
+++ b/server/lib/seasonalLeaderboard.js
@@ -53,6 +53,22 @@ function toFiniteNonNegative(value) {
   return num;
 }
 
+// Live cards cap each stat at 10 (legacy saves used a 1–200 scale). Deck docs
+// are client-writable, so scoring must clamp per-stat values onto the live
+// scale — otherwise a forged deck with e.g. speed: 999999 tops the leaderboard.
+const MAX_SINGLE_STAT = 10;
+const LEGACY_MAX_SINGLE_STAT = 200;
+
+function toBoundedStat(value) {
+  const num = toFiniteNonNegative(value);
+  if (num <= MAX_SINGLE_STAT) return num;
+
+  const scaled = 1
+    + ((Math.min(num, LEGACY_MAX_SINGLE_STAT) - 1) * (MAX_SINGLE_STAT - 1))
+      / (LEGACY_MAX_SINGLE_STAT - 1);
+  return Math.min(MAX_SINGLE_STAT, Math.round(scaled));
+}
+
 function getCardArchetype(card) {
   return card?.prompts?.archetype ?? card?.archetype ?? 'Unknown';
 }
@@ -78,7 +94,7 @@ function getSynergyMultiplier(cards) {
 export function computeDeckScore(cards) {
   if (!Array.isArray(cards) || cards.length === 0) return 0;
   const raw = cards.reduce(
-    (sum, card) => sum + STAT_KEYS.reduce((cardSum, key) => cardSum + toFiniteNonNegative(card?.stats?.[key]), 0),
+    (sum, card) => sum + STAT_KEYS.reduce((cardSum, key) => cardSum + toBoundedStat(card?.stats?.[key]), 0),
     0,
   );
   return Math.round(raw * getSynergyMultiplier(cards));
@@ -87,7 +103,7 @@ export function computeDeckScore(cards) {
 export function computeDeckWorth(cards) {
   if (!Array.isArray(cards)) return 0;
   return cards.reduce(
-    (sum, card) => sum + STAT_KEYS.reduce((cardSum, key) => cardSum + toFiniteNonNegative(card?.stats?.[key]), 0),
+    (sum, card) => sum + STAT_KEYS.reduce((cardSum, key) => cardSum + toBoundedStat(card?.stats?.[key]), 0),
     0,
   );
 }
@@ -116,7 +132,7 @@ export function buildLeaderboardDeckSummary(cards) {
   const statTotals = Object.fromEntries(STAT_KEYS.map((key) => [key, 0]));
   for (const card of cards) {
     for (const key of STAT_KEYS) {
-      statTotals[key] += toFiniteNonNegative(card?.stats?.[key]);
+      statTotals[key] += toBoundedStat(card?.stats?.[key]);
     }
   }
   const strongestStat = STAT_KEYS.reduce((best, key) => (statTotals[key] > statTotals[best] ? key : best), STAT_KEYS[0]);

--- a/server/test/battle.test.js
+++ b/server/test/battle.test.js
@@ -27,6 +27,27 @@ test('resolveBattleWithEffects is deterministic for a given seed', () => {
   assert.equal(first.winnerSide, 'challenger');
 });
 
+test('createBattleCardSnapshot clamps forged and legacy stats onto the live 1-10 scale', () => {
+  assert.deepEqual(
+    createBattleCardSnapshot({
+      id: 'card-forged',
+      prompts: {},
+      stats: { speed: 999999, stealth: 200, tech: 100, grit: -5, rep: 'not-a-number' },
+    }),
+    {
+      id: 'card-forged',
+      archetype: undefined,
+      stats: {
+        speed: 10,
+        stealth: 10,
+        tech: 5, // legacy 1-200 scale value rescaled like the client
+        grit: 1,
+        rep: 1,
+      },
+    },
+  );
+});
+
 test('createBattleCardSnapshot clamps missing stats to minimum numeric values', () => {
   assert.deepEqual(
     createBattleCardSnapshot({ id: 'card-1', stats: { speed: 9 }, prompts: {} }),

--- a/server/test/seasonalLeaderboard.test.js
+++ b/server/test/seasonalLeaderboard.test.js
@@ -50,6 +50,25 @@ test('seasonal cooldown is four hours', () => {
   assert.equal(SEASONAL_SUBMISSION_COOLDOWN_HOURS, 4);
 });
 
+test('forged oversized card stats are clamped to the live per-stat cap', () => {
+  const forgedCards = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) =>
+    makeCard(id, 'Courier', { speed: 999999, range: 500000, stealth: 123456, grit: 777777 }),
+  );
+  const legitMaxCards = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) => makeCard(id));
+  const forgedSummary = buildLeaderboardDeckSummary(forgedCards);
+  const legitSummary = buildLeaderboardDeckSummary(legitMaxCards);
+  assert.equal(forgedSummary.deckPower, legitSummary.deckPower);
+});
+
+test('legacy 1-200 scale stats are rescaled instead of dominating', () => {
+  const legacyCards = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) =>
+    makeCard(id, 'Courier', { speed: 100, range: 100, stealth: 100, grit: 100 }),
+  );
+  const summary = buildLeaderboardDeckSummary(legacyCards);
+  // Legacy 100 maps to ~5.5 -> 5 per stat on the live scale.
+  assert.ok(summary.deckPower <= 276, 'legacy decks must not exceed the live max deck power');
+});
+
 test('non-numeric card stats do not poison deck score with NaN', () => {
   const cards = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) =>
     makeCard(id, 'Courier', { speed: 'oops', range: null, stealth: undefined, grit: 10 }),

--- a/src/components/AdminFactionImagesPanel.tsx
+++ b/src/components/AdminFactionImagesPanel.tsx
@@ -29,7 +29,7 @@ function getLegacyFactionStoragePath(slug: string, ext?: string): string | null 
 }
 
 export function AdminFactionImagesPanel() {
-  const [selectedFaction, setSelectedFaction] = useState(FACTION_LORE[0].name);
+  const [selectedFaction, setSelectedFaction] = useState<string>(FACTION_LORE[0].name);
   const [factionImageFile, setFactionImageFile] = useState<File | null>(null);
   const [factionImagePreview, setFactionImagePreview] = useState<string | null>(null);
   const [factionCurrentImages, setFactionCurrentImages] = useState<Record<string, string>>({});

--- a/src/components/GeoAtlas.tsx
+++ b/src/components/GeoAtlas.tsx
@@ -63,6 +63,12 @@ const PLAYABLE_DISTRICTS: District[] = [
   "Glass City",
 ];
 
+const PLAYABLE_DISTRICT_SET = new Set<WorldLocation>(PLAYABLE_DISTRICTS);
+
+function isPlayableDistrict(name: WorldLocation): name is District {
+  return PLAYABLE_DISTRICT_SET.has(name);
+}
+
 const AUSTRALIA_DISTRICT_LAYOUT: Record<WorldLocation, { x: number; y: number; tone: string }> = {
   Airaway: { x: 68, y: 57, tone: "sky" },
   Electropolis: { x: 74, y: 40, tone: "signal" },
@@ -271,13 +277,16 @@ export const GeoAtlas = memo(function GeoAtlas({
   const hasFocus = focusDistrictSet.size > 0 || focusCorridorSet.size > 0;
   const districtEntries = useMemo(
     () =>
-      DISTRICT_LORE.map((entry) => ({
-        ...entry,
-        layout: AUSTRALIA_DISTRICT_LAYOUT[entry.name],
-        slug: entry.name.toLowerCase().replace(/\s+/g, "-"),
-        weather: entry.kind === "district" ? weatherByDistrict[entry.name] ?? null : null,
-        location: entry.kind === "district" ? DISTRICT_WEATHER_LOCATIONS[entry.name] : null,
-      })),
+      DISTRICT_LORE.map((entry) => {
+        const districtName = entry.kind === "district" && isPlayableDistrict(entry.name) ? entry.name : null;
+        return {
+          ...entry,
+          layout: AUSTRALIA_DISTRICT_LAYOUT[entry.name],
+          slug: entry.name.toLowerCase().replace(/\s+/g, "-"),
+          weather: districtName ? weatherByDistrict[districtName] ?? null : null,
+          location: districtName ? DISTRICT_WEATHER_LOCATIONS[districtName] : null,
+        };
+      }),
     [weatherByDistrict],
   );
   const { activeDistrictEntry } = useMemo(() => {
@@ -303,7 +312,7 @@ export const GeoAtlas = memo(function GeoAtlas({
       ).length
     : null;
   const inspectionCopy = activeDistrictEntry
-    ? activeDistrictEntry.kind === "district"
+    ? activeDistrictEntry.kind === "district" && isPlayableDistrict(activeDistrictEntry.name)
       ? {
           name: activeDistrictEntry.name,
           weatherSummary: getDistrictWeatherSummary({
@@ -482,9 +491,10 @@ export const GeoAtlas = memo(function GeoAtlas({
 
                 {districtEntries.filter((district) => district.kind !== "hidden").map((district) => {
                   const accessRestricted =
-                    district.kind === "district" && hasDistrictAccessRestriction(district.name, district.weather);
+                    district.kind === "district" && isPlayableDistrict(district.name)
+                      && hasDistrictAccessRestriction(district.name, district.weather);
                   const boardAccessible =
-                    boardConfig && district.kind === "district"
+                    boardConfig && district.kind === "district" && isPlayableDistrict(district.name)
                       ? isDistrictAccessibleWithBoardType(
                           district.name,
                           district.weather,
@@ -493,7 +503,7 @@ export const GeoAtlas = memo(function GeoAtlas({
                         )
                       : null;
                   const detailText =
-                    district.kind === "district"
+                    district.kind === "district" && isPlayableDistrict(district.name)
                       ? `${district.name}. ${getDistrictWeatherSummary({
                           district: district.name,
                           weatherSummary: district.weather?.summary ?? null,
@@ -539,7 +549,7 @@ export const GeoAtlas = memo(function GeoAtlas({
                         {...commonProps}
                         onClick={() => {
                           inspectDistrict();
-                          if (district.kind === "district" && onDistrictSelect) {
+                          if (district.kind === "district" && isPlayableDistrict(district.name) && onDistrictSelect) {
                             onDistrictSelect(district.name);
                           }
                         }}

--- a/src/components/TierModal.tsx
+++ b/src/components/TierModal.tsx
@@ -169,7 +169,7 @@ export function TierModal({ onClose }: TierModalProps) {
           <div className="tier-signup">
             <button className="btn-outline tier-back" onClick={() => setSignupStep(null)}>← Back</button>
             <h3 className="tier-signup-title">
-              {signupStep === "seasonPass" ? `Buy ${SEASON_PASS.name}` : `Sign up for ${signupTier.name}`}
+              {signupTier ? `Sign up for ${signupTier.name}` : `Buy ${SEASON_PASS.name}`}
             </h3>
             <p className="tier-signup-desc">
               {signupStep === "seasonPass"
@@ -208,7 +208,7 @@ export function TierModal({ onClose }: TierModalProps) {
               {loading
                 ? "Redirecting to payment…"
                 : `Continue to Payment — ${
-                  signupStep === "seasonPass"
+                  !signupTier
                     ? SEASON_PASS.price
                     : billingPeriod === "annual"
                       ? signupTier.annualPrice ?? signupTier.price

--- a/src/components/TradeModal.tsx
+++ b/src/components/TradeModal.tsx
@@ -49,14 +49,15 @@ export function TradeModal({ cards, onClose, preselectedCard }: TradeModalProps)
   const senderReputation = user ? createTradeReputationSnapshot(sentTrades, user.uid) : null;
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || !db) return;
+    const firestore = db;
     let cancelled = false;
 
     const loadPendingOffers = async () => {
       setLoadingPendingOffers(true);
       try {
         const sentTradesSnap = await getDocs(
-          query(collection(db, "trades"), where("fromUid", "==", user.uid))
+          query(collection(firestore, "trades"), where("fromUid", "==", user.uid))
         );
         if (cancelled) return;
         setSentTrades(sentTradesSnap.docs.map((docSnap) => docSnap.data() as TradePayload));

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -104,6 +104,8 @@ export function useCollection() {
       return;
     }
 
+    if (!db) return;
+
     guestHydratingRef.current = false;
     initialGuestCardsRef.current = null;
     lastSavedCardsRef.current = [];
@@ -149,7 +151,7 @@ export function useCollection() {
   // ── Card mutations ────────────────────────────────────────────────────────
   const addCard = useCallback(async (card: CardPayload): Promise<void> => {
     const normalizedCard = normalizeCardPayload(card);
-    if (uid) {
+    if (uid && db) {
       await setDoc(doc(db, "users", uid, "cards", normalizedCard.id), normalizedCard);
     } else {
       setCards((prev) => (prev.some((c) => c.id === normalizedCard.id) ? prev : [...prev, normalizedCard]));
@@ -157,7 +159,7 @@ export function useCollection() {
   }, [uid]);
 
   const removeCard = useCallback((id: string) => {
-    if (uid) {
+    if (uid && db) {
       deleteDoc(doc(db, "users", uid, "cards", id)).catch((error) => reportPersistenceError("Couldn't remove that card — check your connection and try again.", error));
     } else {
       setCards((prev) => prev.filter((c) => c.id !== id));
@@ -166,7 +168,7 @@ export function useCollection() {
 
   const updateCard = useCallback((card: CardPayload) => {
     const normalizedCard = normalizeCardPayload(card);
-    if (uid) {
+    if (uid && db) {
       setDoc(doc(db, "users", uid, "cards", normalizedCard.id), normalizedCard).catch((error) => reportPersistenceError("Couldn't save your card changes — check your connection and try again.", error));
     } else {
       setCards((prev) => prev.map((c) => (c.id === normalizedCard.id ? normalizedCard : c)));
@@ -178,7 +180,7 @@ export function useCollection() {
 
   // ── Migration helpers ─────────────────────────────────────────────────────
   const importLocalCards = useCallback(async () => {
-    if (!uid) return;
+    if (!uid || !db) return;
     const local = loadCollection();
     if (local.length > 0) {
       const batch = writeBatch(db);

--- a/src/hooks/useDecks.ts
+++ b/src/hooks/useDecks.ts
@@ -75,12 +75,15 @@ export function useDecks() {
       return;
     }
 
+    if (!db) return;
+    const firestore = db;
+
     guestHydratingRef.current = false;
     initialGuestDecksRef.current = null;
     lastSavedDecksRef.current = [];
     setDecks([]);
 
-    const colRef = collection(db, "users", uid, "decks");
+    const colRef = collection(firestore, "users", uid, "decks");
     const unsub = onSnapshot(colRef, (snap) => {
       const incoming = snap.docs.map((d) => d.data() as DeckPayload);
       const normalized = normalizeDeckOrder(incoming);
@@ -93,7 +96,7 @@ export function useDecks() {
       });
 
       if (changedDecks.length > 0) {
-        void Promise.all(changedDecks.map((deck) => setDoc(doc(db, "users", uid, "decks", deck.id), deck))).catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
+        void Promise.all(changedDecks.map((deck) => setDoc(doc(firestore, "users", uid, "decks", deck.id), deck))).catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
       }
     });
     return unsub;
@@ -120,7 +123,7 @@ export function useDecks() {
 
   // ── Helpers ───────────────────────────────────────────────────────────────
   const saveDeck = useCallback((deck: DeckPayload) => {
-    if (uid) {
+    if (uid && db) {
       setDoc(doc(db, "users", uid, "decks", deck.id), deck).catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
     } else {
       setDecks((prev) => prev.map((d) => (d.id === deck.id ? deck : d)));
@@ -139,7 +142,7 @@ export function useDecks() {
       updatedAt: new Date().toISOString(),
       sortOrder: nextSortOrder,
     };
-    if (uid) {
+    if (uid && db) {
       setDoc(doc(db, "users", uid, "decks", deck.id), deck).catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
     } else {
       setDecks((prev) => normalizeDeckOrder([...prev, deck]));
@@ -148,7 +151,7 @@ export function useDecks() {
   }, [uid]);
 
   const deleteDeck = useCallback((id: string) => {
-    if (uid) {
+    if (uid && db) {
       deleteDoc(doc(db, "users", uid, "decks", id)).catch((error) => reportPersistenceError("Couldn't delete that deck — check your connection and try again.", error));
     } else {
       setDecks((prev) => prev.filter((d) => d.id !== id));
@@ -242,8 +245,9 @@ export function useDecks() {
 
     setDecks(normalized);
 
-    if (uid) {
-      void Promise.all(normalized.map((deck) => setDoc(doc(db, "users", uid, "decks", deck.id), deck))).catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
+    if (uid && db) {
+      const firestore = db;
+      void Promise.all(normalized.map((deck) => setDoc(doc(firestore, "users", uid, "decks", deck.id), deck))).catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
     }
   }, [uid]);
 
@@ -272,7 +276,7 @@ export function useDecks() {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
-    if (uid) {
+    if (uid && db) {
       setDoc(doc(db, "users", uid, "decks", deck.id), deck).catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
     } else {
       setDecks((prev) => [...prev, deck]);
@@ -286,10 +290,11 @@ export function useDecks() {
       const shouldBePrimary = deck.id === deckId;
       if (Boolean(deck.isPrimary) === shouldBePrimary) return null;
       return { ...deck, isPrimary: shouldBePrimary, updatedAt: now };
-    }).filter((d): d is DeckPayload => d !== null);
+    }).filter((d): d is NonNullable<typeof d> => d !== null);
     if (updates.length === 0) return;
-    if (uid) {
-      void Promise.all(updates.map((deck) => setDoc(doc(db, "users", uid, "decks", deck.id), deck)))
+    if (uid && db) {
+      const firestore = db;
+      void Promise.all(updates.map((deck) => setDoc(doc(firestore, "users", uid, "decks", deck.id), deck)))
         .catch((error) => reportPersistenceError("Couldn't save your deck changes — check your connection and try again.", error));
     } else {
       setDecks((prev) => prev.map((d) => {

--- a/src/hooks/useDistrictWeather.ts
+++ b/src/hooks/useDistrictWeather.ts
@@ -36,30 +36,35 @@ function fetchDistrictWeather(): Promise<DistrictWeatherResponse> {
 
 async function requestDistrictWeather(forceRefresh = false): Promise<DistrictWeatherResponse> {
   const now = Date.now();
+  const cachedResponse = cachedWeatherResponse;
   const hasFreshCache =
     !forceRefresh &&
-    cachedWeatherResponse &&
+    cachedResponse &&
     now - cachedWeatherFetchedAt < DISTRICT_WEATHER_REFRESH_MS;
 
   if (hasFreshCache) {
-    return cachedWeatherResponse;
+    return cachedResponse;
   }
 
   if (inFlightWeatherRequest) {
     return inFlightWeatherRequest;
   }
 
-  if (!queuedWeatherRequest) {
-    queuedWeatherRequest = new Promise((resolve, reject) => {
-      window.setTimeout(() => {
-        fetchDistrictWeather().then(resolve, reject);
-      }, DISTRICT_WEATHER_DEBOUNCE_MS);
-    }).finally(() => {
-      queuedWeatherRequest = null;
-    });
+  const pendingRequest = queuedWeatherRequest;
+  if (pendingRequest) {
+    return pendingRequest;
   }
 
-  return queuedWeatherRequest;
+  const nextRequest = new Promise<DistrictWeatherResponse>((resolve, reject) => {
+    window.setTimeout(() => {
+      fetchDistrictWeather().then(resolve, reject);
+    }, DISTRICT_WEATHER_DEBOUNCE_MS);
+  }).finally(() => {
+    queuedWeatherRequest = null;
+  });
+  queuedWeatherRequest = nextRequest;
+
+  return nextRequest;
 }
 
 function getErrorMessage(error: unknown): string {

--- a/src/hooks/useWorkshopBoards.ts
+++ b/src/hooks/useWorkshopBoards.ts
@@ -41,6 +41,8 @@ export function useWorkshopBoards() {
       return;
     }
 
+    if (!db) return;
+
     setIsLoading(true);
     guestHydratingRef.current = false;
     initialGuestBoardsRef.current = null;
@@ -70,7 +72,7 @@ export function useWorkshopBoards() {
   }, [boards, uid]);
 
   const saveBoard = useCallback(async (board: WorkshopBoardPayload) => {
-    if (uid) {
+    if (uid && db) {
       await setDoc(doc(db, "users", uid, "workshopBoards", board.id), board, { merge: true });
       return;
     }
@@ -86,7 +88,7 @@ export function useWorkshopBoards() {
   }, [saveBoard]);
 
   const removeBoard = useCallback(async (boardId: string) => {
-    if (uid) {
+    if (uid && db) {
       await deleteDoc(doc(db, "users", uid, "workshopBoards", boardId));
       return;
     }
@@ -102,15 +104,16 @@ export function useWorkshopBoards() {
           const board = byId.get(id);
           return board ? { ...board, sortOrder: index } : null;
         })
-        .filter((b): b is WorkshopBoardPayload => b !== null);
+        .filter((b): b is NonNullable<typeof b> => b !== null);
       // Preserve any boards whose IDs were not in orderedIds (append after reordered ones)
       const trailing = prev.filter((b) => !orderedSet.has(b.id));
       return [...reordered, ...trailing];
     });
-    if (uid) {
+    if (uid && db) {
+      const firestore = db;
       await Promise.all(
         orderedIds.map((id, index) => {
-          const ref = doc(db, "users", uid, "workshopBoards", id);
+          const ref = doc(firestore, "users", uid, "workshopBoards", id);
           return setDoc(ref, { sortOrder: index }, { merge: true });
         }),
       );

--- a/src/hooks/useWorkshopWeapons.ts
+++ b/src/hooks/useWorkshopWeapons.ts
@@ -41,6 +41,8 @@ export function useWorkshopWeapons() {
       return;
     }
 
+    if (!db) return;
+
     setIsLoading(true);
     guestHydratingRef.current = false;
     initialGuestWeaponsRef.current = null;
@@ -70,7 +72,7 @@ export function useWorkshopWeapons() {
   }, [weapons, uid]);
 
   const saveWeapon = useCallback(async (weapon: WorkshopWeaponPayload) => {
-    if (uid) {
+    if (uid && db) {
       await setDoc(doc(db, "users", uid, "workshopWeapons", weapon.id), weapon, { merge: true });
       return;
     }
@@ -86,7 +88,7 @@ export function useWorkshopWeapons() {
   }, [saveWeapon]);
 
   const removeWeapon = useCallback(async (weaponId: string) => {
-    if (uid) {
+    if (uid && db) {
       await deleteDoc(doc(db, "users", uid, "workshopWeapons", weaponId));
       return;
     }

--- a/src/lib/boardPlacement.ts
+++ b/src/lib/boardPlacement.ts
@@ -19,7 +19,7 @@ interface PlacementBox {
   heightPercent: number;
 }
 
-interface PlacementPreset<TPlacement extends LayerPlacement> extends PlacementBox, TPlacement {}
+type PlacementPreset<TPlacement extends LayerPlacement> = PlacementBox & TPlacement;
 
 const BOARD_PLACEMENT_PRESETS: Record<BoardPoseSceneKey, PlacementPreset<BoardPlacement>> = {
   workshop: { xPercent: 38, yPercent: 77.5, scale: 1, rotationDeg: -9, widthPercent: 68, heightPercent: 25 },
@@ -58,12 +58,12 @@ function getValidNumberOrDefault(value: number | null | undefined, fallback: num
   return Number.isFinite(value) ? Number(value) : fallback;
 }
 
-function normalizePlacement<TPlacement extends LayerPlacement>(
-  preset: PlacementPreset<TPlacement>,
-  placement: Partial<TPlacement> | undefined,
+function normalizePlacement(
+  preset: PlacementPreset<LayerPlacement>,
+  placement: Partial<LayerPlacement> | undefined,
   minScale: number,
   maxScale: number,
-): TPlacement {
+): LayerPlacement {
   const scale = clampPlacementValue(
     getValidNumberOrDefault(placement?.scale, preset.scale),
     minScale,

--- a/src/lib/craftlingua.ts
+++ b/src/lib/craftlingua.ts
@@ -11,8 +11,28 @@ const CRAFTLINGUA_BASE_URL = "https://craftlingua.app";
 
 export const CRAFTLINGUA_ATTRIBUTION = "Language system powered by CraftLingua.";
 
-export const CRAFTLINGUA_DISTRICT_LANGUAGES =
-  craftlinguaDistrictsRaw as CraftlinguaDistrictLanguage[];
+const CRAFTLINGUA_DISTRICT_NAMES = new Set<string>([
+  "Airaway",
+  "Batteryville",
+  "The Grid",
+  "Nightshade",
+  "The Forest",
+  "Glass City",
+] satisfies District[]);
+
+function isCraftlinguaDistrict(value: string): value is District {
+  return CRAFTLINGUA_DISTRICT_NAMES.has(value);
+}
+
+export const CRAFTLINGUA_DISTRICT_LANGUAGES: CraftlinguaDistrictLanguage[] =
+  craftlinguaDistrictsRaw.flatMap((entry) => {
+    if (!isCraftlinguaDistrict(entry.district)) return [];
+    const phrasebook: Record<string, string> = {};
+    for (const [phrase, translation] of Object.entries(entry.phrasebook)) {
+      if (typeof translation === "string") phrasebook[phrase] = translation;
+    }
+    return [{ ...entry, district: entry.district, phrasebook }];
+  });
 
 export function buildCraftlinguaExploreUrl(shareCode: string): string {
   return `${CRAFTLINGUA_BASE_URL}/share/${encodeURIComponent(shareCode)}`;

--- a/src/lib/districtTheme.ts
+++ b/src/lib/districtTheme.ts
@@ -135,7 +135,9 @@ const SLUG_BY_NAME = new Map<string, RaceDistrictSlug>(
     [option.displayName.toLowerCase().replace(/\s+/g, "-"), option.slug],
   ]),
 );
-const DISTRICT_LORE_BY_NAME = new Map(DISTRICT_LORE.map((entry) => [entry.name, entry] as const));
+const DISTRICT_LORE_BY_NAME = new Map<string, (typeof DISTRICT_LORE)[number]>(
+  DISTRICT_LORE.map((entry) => [entry.name, entry] as const),
+);
 const DISTRICT_LANGUAGE_BY_SLUG = new Map(CRAFTLINGUA_DISTRICT_LANGUAGES.map((entry) => [entry.slug, entry] as const));
 
 export function normalizeDistrictSlug(district?: string | null): RaceDistrictSlug {

--- a/src/lib/missions.ts
+++ b/src/lib/missions.ts
@@ -97,8 +97,8 @@ const MISSION_JOUST_RIVAL_FALLBACKS: Partial<Record<District, MissionJoustRivalC
     rival: {
       id: "forest-rootline-guide",
       name: "Knot Runner",
-      archetype: "Wooders",
-      crew: "Wooders",
+      archetype: "The Team",
+      crew: "The Wooders",
       district: "The Forest",
       stats: { speed: 6, range: 5, rangeNm: 5, stealth: 5, grit: 8 },
       joust: {
@@ -616,7 +616,6 @@ function buildMissionStoryBeats({
 }
 
 function buildMissionRewardSignals(
-  mission: MissionBoardEntry,
   activeRun: MissionActiveRunState | null | undefined,
   selectedOption: MissionEncounterOption | null,
   joustResult: MissionJoustResult | null,
@@ -1584,7 +1583,7 @@ export function resolveMissionCounterChoice(
   }
   if (selectedOption.encounterType === "joust") {
     const joustResult = resolveMissionJoust(mission, deck, activeRun, playerTactic);
-    const rewardSignals = buildMissionRewardSignals(mission, activeRun, selectedOption, joustResult);
+    const rewardSignals = buildMissionRewardSignals(activeRun, selectedOption, joustResult);
     const signalTotals = getMissionRewardSignalTotals(rewardSignals);
     const rewards = joustResult ? getMissionJoustRewards(joustResult) : MISSION_JOUST_BASE_REWARDS.loss;
     const rivalPressure = activeRun?.rivalPressure ?? null;
@@ -1615,7 +1614,7 @@ export function resolveMissionCounterChoice(
       rivalPressure,
     };
   }
-  const rewardSignals = buildMissionRewardSignals(mission, activeRun, selectedOption, null);
+  const rewardSignals = buildMissionRewardSignals(activeRun, selectedOption, null);
   const signalTotals = getMissionRewardSignalTotals(rewardSignals);
   const rivalPressure = activeRun?.rivalPressure ?? null;
   return {

--- a/src/lib/rivals.ts
+++ b/src/lib/rivals.ts
@@ -531,9 +531,11 @@ export function createDistrictRivalBattleCardSnapshot(
 ): BattleCardSnapshot | undefined {
   const rival = typeof rivalOrId === "string" ? getDistrictRival(rivalOrId) : rivalOrId;
   if (!rival) return undefined;
+  const { archetype } = rival.signatureCard;
+  if (!archetype) return undefined;
   return {
     id: rival.signatureCard.id,
-    archetype: rival.signatureCard.archetype,
+    archetype,
     stats: { ...rival.signatureCard.stats },
   };
 }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -414,6 +414,7 @@ export function Admin() {
 
   // ── Fetch user count ───────────────────────────────────────────────────────
   useEffect(() => {
+    if (!db) return;
     getCountFromServer(collection(db, "userProfiles"))
       .then((snap) => setTotalUsers(snap.data().count))
       .catch(() => {});
@@ -421,6 +422,7 @@ export function Admin() {
 
   // ── Load first page ────────────────────────────────────────────────────────
   const loadUsers = useCallback(async (after?: DocumentSnapshot) => {
+    if (!db) return;
     setLoading(true);
     setError("");
     try {
@@ -463,6 +465,7 @@ export function Admin() {
 
   // ── Set tier for a user ────────────────────────────────────────────────────
   const handleSetTier = async (uid: string, newTier: TierLevel) => {
+    if (!db) return;
     setSavingUid(uid);
     setSuccessUid(null);
     try {

--- a/src/pages/BossAssets.tsx
+++ b/src/pages/BossAssets.tsx
@@ -35,7 +35,7 @@ export function BossAssets() {
   const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
-    if (!user?.uid || userProfile?.isAdmin !== true) return;
+    if (!user?.uid || userProfile?.isAdmin !== true || !db) return;
 
     const collRef = collection(db, BOSS_ASSETS_COLLECTION);
     const unsubscribe = onSnapshot(collRef, (snapshot) => {
@@ -65,6 +65,7 @@ export function BossAssets() {
   }, []);
 
   const handleRemove = useCallback(async (card: CardPayload) => {
+    if (!db) return;
     if (!confirm(`Remove "${card.identity.name}" from Boss Assets?`)) return;
     sfxRemove();
     try {
@@ -118,11 +119,14 @@ export function BossAssets() {
         <div className="collection-grid">
           {filteredCards.map((card) => (
             <div key={card.id} className="collection-grid__item">
-              <CardThumbnail
-                card={card}
+              <button
+                type="button"
+                className={`card-thumb${selected?.id === card.id ? " card-thumb--selected" : ""}`}
                 onClick={() => handleSelect(card)}
-                selected={selected?.id === card.id}
-              />
+                aria-label={`View ${card.identity.name}`}
+              >
+                <CardThumbnail card={card} />
+              </button>
               <button
                 className="btn-outline btn-sm btn-danger"
                 onClick={() => handleRemove(card)}

--- a/src/pages/ClassicRace.tsx
+++ b/src/pages/ClassicRace.tsx
@@ -228,7 +228,7 @@ function ChallengeModal({
 }) {
   const [defenderCardId, setDefenderCardId] = useState(state.defenderCardId);
   const [wager, setWager] = useState(0);
-  const [district, setDistrict] = useState(DEFAULT_RACE_DISTRICT);
+  const [district, setDistrict] = useState<string>(DEFAULT_RACE_DISTRICT);
   const defenderCard = state.opponent.cards.find((c) => c.id === defenderCardId);
   const cap = Math.max(0, Math.min(myOzzies, 10_000));
   const dialogRef = useModalA11y<HTMLDivElement>({ onClose, active: true });

--- a/src/pages/Collection.tsx
+++ b/src/pages/Collection.tsx
@@ -722,7 +722,7 @@ export function Collection() {
                    "--carousel-offset": carouselOffset,
                    "--carousel-abs-offset": carouselAbsOffset,
                    zIndex: cardZIndex,
-                 } satisfies CarouselCardStyle}
+                 } as CarouselCardStyle}
                  role={isCarouselVisible ? "listitem" : "presentation"}
                  aria-current={isCarouselActive ? "true" : undefined}
                  aria-hidden={!isCarouselVisible}

--- a/src/pages/ForgeClash.tsx
+++ b/src/pages/ForgeClash.tsx
@@ -131,7 +131,7 @@ function resolvePlay(card: CardPayload, state: ClashState): {
   const nextHeat = clamp(state.heat + (crit ? 9 : 5) + counter.value / 2 - (slip ? 4 : 0), 0, 30);
   const decrementedCooldowns = Object.fromEntries(
     Object.entries(state.cooldowns)
-      .map(([id, value]) => [id, Math.max(0, value - 1)])
+      .map(([id, value]) => [id, Math.max(0, value - 1)] as const)
       .filter(([, value]) => value > 0),
   );
   const cooldowns = { ...decrementedCooldowns, [card.id]: 2 };

--- a/src/pages/Missions.tsx
+++ b/src/pages/Missions.tsx
@@ -1150,14 +1150,14 @@ function MissionsWorldView({ uid, userEmail }: { uid: string; userEmail?: string
     try {
       const launchRunner = selectedRunner.runnerType === "card"
         ? {
-          runnerType: "card",
+          runnerType: "card" as const,
           cardId: selectedRunner.card?.id ?? null,
           cardName: selectedRunner.label,
           deckId: null,
           deckName: null,
         }
         : {
-          runnerType: "deck",
+          runnerType: "deck" as const,
           deckId: selectedRunner.deck?.id ?? null,
           deckName: selectedRunner.label,
           cardId: null,

--- a/src/pages/Trades.tsx
+++ b/src/pages/Trades.tsx
@@ -53,7 +53,7 @@ export function Trades() {
     setMarket([]);
     setSelectedLeaderboardDeckId(null);
     setLeaderboardSuccess(false);
-    if (!uid) return;
+    if (!uid || !db) return;
 
     setError("");
 
@@ -97,7 +97,7 @@ export function Trades() {
   }, [uid, refreshKey]);
 
   const handleAccept = async (trade: TradePayload) => {
-    if (!user) return;
+    if (!user || !db) return;
     setActionLoading(trade.id);
     setError("");
     try {
@@ -162,6 +162,7 @@ export function Trades() {
     expectedActorUid: string,
     ownershipError: string,
   ) => {
+    if (!db) return;
     const tradeRef = doc(db, "trades", trade.id);
     await runTransaction(db, async (tx) => {
       const tradeSnap = await tx.get(tradeRef);

--- a/src/pages/Workshop.tsx
+++ b/src/pages/Workshop.tsx
@@ -37,10 +37,12 @@ import {
   CHARACTER_PLACEMENT_MAX_SCALE,
   CHARACTER_PLACEMENT_MIN_SCALE,
   CHARACTER_PLACEMENT_SCALE_STEP,
+  normalizeBoardPlacement,
   WEAPON_PLACEMENT_MAX_SCALE,
   WEAPON_PLACEMENT_MIN_SCALE,
   WEAPON_PLACEMENT_SCALE_STEP,
 } from "../lib/boardPlacement";
+import { resolveBoardPoseScene } from "../lib/boardPoseScenes";
 import { WEAPON_ASSETS } from "./cardForge/constants";
 
 async function generateTransparentBoardArt(
@@ -82,7 +84,7 @@ function getWorkshopAssetKey(kind: WorkshopAssetKind, id: string): string {
 function isValidFloorPlacement(
   placement: WorkshopFloorPlacement | undefined,
 ): placement is WorkshopFloorPlacement {
-  return Boolean(placement)
+  return placement != null
     && Number.isFinite(placement.x)
     && Number.isFinite(placement.y);
 }
@@ -397,10 +399,14 @@ export function Workshop() {
     ));
   };
 
+  const editingBoardPlacement = editingCard
+    ? normalizeBoardPlacement(resolveBoardPoseScene(editingCard.characterSeed).key, editingCard.board.placement)
+    : null;
+
   const updateBoardPlacement = (patch: Partial<BoardPlacement>) => {
-    if (!editingCard) return;
+    if (!editingCard || !editingBoardPlacement) return;
     handleBoardPlacementChange({
-      ...editingCard.board.placement,
+      ...editingBoardPlacement,
       ...patch,
     });
   };
@@ -931,7 +937,7 @@ export function Workshop() {
               </div>
             )}
 
-            {editingCard && cardEditorVars && (
+            {editingCard && editingBoardPlacement && cardEditorVars && (
               <>
                 <label className="workshop-field">
                   <span>Rename courier</span>
@@ -1006,7 +1012,7 @@ export function Workshop() {
                   <div className="blend-control">
                     <label className="blend-control__label">
                       <span>Skateboard Size</span>
-                      <span>{Math.round(editingCard.board.placement.scale * 100)}%</span>
+                      <span>{Math.round(editingBoardPlacement.scale * 100)}%</span>
                     </label>
                     <input
                       type="range"
@@ -1014,7 +1020,7 @@ export function Workshop() {
                       min={BOARD_PLACEMENT_MIN_SCALE}
                       max={BOARD_PLACEMENT_MAX_SCALE}
                       step={BOARD_PLACEMENT_SCALE_STEP}
-                      value={editingCard.board.placement.scale}
+                      value={editingBoardPlacement.scale}
                       onChange={(event) => updateBoardPlacement({ scale: Number(event.target.value) })}
                       aria-label="Workshop skateboard size"
                     />
@@ -1022,7 +1028,7 @@ export function Workshop() {
                   <div className="blend-control">
                     <label className="blend-control__label">
                       <span>Skateboard Rotation</span>
-                      <span>{Math.round(editingCard.board.placement.rotationDeg)}°</span>
+                      <span>{Math.round(editingBoardPlacement.rotationDeg)}°</span>
                     </label>
                     <input
                       type="range"
@@ -1030,7 +1036,7 @@ export function Workshop() {
                       min={-180}
                       max={180}
                       step={1}
-                      value={editingCard.board.placement.rotationDeg}
+                      value={editingBoardPlacement.rotationDeg}
                       onChange={(event) => updateBoardPlacement({ rotationDeg: Number(event.target.value) })}
                       aria-label="Workshop skateboard rotation"
                     />

--- a/src/pages/cardForge/useForgeGeneration.ts
+++ b/src/pages/cardForge/useForgeGeneration.ts
@@ -222,6 +222,7 @@ export function useForgeGeneration() {
         seed: card.frameSeed,
         generationOptions: { loras: [] },
       },
+      weapon: null,
     };
   }, []);
 
@@ -295,7 +296,7 @@ export function useForgeGeneration() {
     setRevealedFaction(null);
     setRevealedRarity(null);
     setLayers({
-      loading: { background: false, character: false, frame: false },
+      loading: { background: false, character: false, frame: false, weapon: false },
       errors: [],
       ...(session?.backgroundUrl != null ? { backgroundUrl: session.backgroundUrl } : {}),
       ...(session?.characterUrl != null ? { characterUrl: session.characterUrl } : {}),
@@ -523,7 +524,7 @@ export function useForgeGeneration() {
     const { signal } = controller;
     const variationKey = buildVariationKey(actionId);
     const nextLayerParams = buildForgeLayerParams(generated, variationKey);
-    const layersToClear = action.targets.filter((target): target is ForgeLayer => target === "character");
+    const layersToClear = action.targets.filter((target): target is "character" => target === "character");
 
     setRerollingActionId(actionId);
     clearRecoveryIssues(layersToClear, action.targets.includes("board"));

--- a/src/pages/cardForge/useForgeSave.ts
+++ b/src/pages/cardForge/useForgeSave.ts
@@ -76,7 +76,7 @@ export function useForgeSave({
   }, [addCard, cards.length, generated, layers, openUpgradeModal, tierData]);
 
   const handleSaveToAdminAssets = useCallback(async () => {
-    if (!generated || !uid) return;
+    if (!generated || !uid || !db) return;
 
     setSaving(true);
     setSaveError(null);

--- a/src/services/imageCache.ts
+++ b/src/services/imageCache.ts
@@ -51,6 +51,7 @@ function encodeKey(key: string): string {
  * Errors are swallowed so a cache miss never blocks generation.
  */
 export async function getCachedImage(cacheKey: string): Promise<string | null> {
+  if (!db) return null;
   try {
     const ref = doc(db, COLLECTION, encodeKey(cacheKey));
     const snap = await getDoc(ref);
@@ -99,6 +100,7 @@ export async function setCachedImage(
  * @throws If the delete operation fails (e.g. permission denied).
  */
 export async function deleteCachedImage(encodedId: string): Promise<void> {
+  if (!db) throw new Error("Firebase is not configured.");
   const ref = doc(db, COLLECTION, encodedId);
   await deleteDoc(ref);
 }
@@ -112,6 +114,7 @@ const CACHE_LIST_PAGE_SIZE = 24;
 export async function listCachedImages(
   after?: DocumentSnapshot,
 ): Promise<{ entries: CacheEntry[]; lastDoc: DocumentSnapshot | null; hasMore: boolean }> {
+  if (!db) return { entries: [], lastDoc: null, hasMore: false };
   const col = collection(db, COLLECTION);
   const q = after
     ? query(col, orderBy("createdAt", "desc"), startAfter(after), limit(CACHE_LIST_PAGE_SIZE))

--- a/storage.rules
+++ b/storage.rules
@@ -1,11 +1,11 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
+    // Admin authority comes from Firebase Auth custom claims (set by the
+    // server's ADMIN_EMAILS sync), matching firestore.rules. This avoids
+    // trusting a Firestore document that could drift out of sync.
     function isAdmin() {
-      return request.auth != null
-        && firestore.get(
-          /databases/(default)/documents/userProfiles/$(request.auth.uid)
-        ).data.isAdmin == true;
+      return request.auth != null && request.auth.token.admin == true;
     }
 
     function isFactionImageAdmin() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sitewide sweep for errors and vulnerabilities: a security review of the Firestore/Storage rules and Express backend, plus fixing every error reported by `npm audit`, `tsc -b`, and the server test suite.

## Security fixes

- **Forgeable `emailLower` (critical)** — `firestore.rules` now requires client-written `email`/`emailLower` on `userProfiles` and `userLookup` to match the verified Firebase Auth token. Previously any signed-in user could claim another player's email and hijack Stripe tier syncs (webhook grants tiers by `emailLower` match) or trade-recipient lookups.
- **Forged card stats (critical)** — deck/card docs are client-writable, but battle resolution and leaderboard scoring trusted embedded stats verbatim. `server/battle.js` and `server/lib/seasonalLeaderboard.js` now clamp every stat onto the live 1–10 scale (with the same legacy 1–200 rescale the client uses), so a forged `speed: 999999` no longer wins battles or tops leaderboards. Regression tests added.
- **Email directory scraping (high)** — `userLookup` allowed any signed-in user to list the whole collection (all users' emails + display names). Listing is now admin-only; single-doc `get` stays available. No client code lists this collection (server lookups use the Admin SDK).
- **Storage admin drift (medium)** — `storage.rules` derived admin from the Firestore `isAdmin` field; it now uses the same Auth custom claim (`request.auth.token.admin`) as `firestore.rules`.
- **Unthrottled public endpoint (medium)** — `/api/hype/crew-faceoff` is unauthenticated and performs Admin SDK reads; a rate limiter was defined for it but never wired up. Now rate limited (30/min).
- **Rate limiting failed open (medium)** — with Redis configured, store errors disabled all rate limiting. The image-generation limiter (which spends real Fal.ai budget) now fails closed; other limiters keep failing open for availability.
- **`innerHTML` in classic-race boot script (low)** — replaced with `textContent`/DOM APIs.
- **npm audit (low)** — `npm audit fix` for the body-parser DoS advisory (GHSA-v422-hmwv-36x6). `npm audit` is now clean.

## Error fixes

- **All 93 TypeScript errors from `tsc -b` fixed.** TypeScript upgraded to ~5.8 (the tsconfigs use `erasableSyntaxOnly`, unknown to 5.6). The bulk were missing null-narrowing for the nullable Firebase exports (`db`/`auth`); the rest were union/literal typing bugs (GeoAtlas `WorldLocation` vs `District`, forge `weapon` layer missing from `Record<ForgeLayer, …>` maps, Workshop assuming `board.placement` exists, invalid `"Wooders"` archetype in missions data, etc.). Runtime behavior is preserved; one genuine bug surfaced: `BossAssets` passed `onClick`/`selected` props that `CardThumbnail` never accepted, so card selection was dead — now wrapped in a real button.
- **Failing server test fixed** — `forgeClashMetrics.test.js` imports a `.ts` module and failed on Node 22; `test:server` now passes `--experimental-strip-types` (a no-op on Node 24 used in CI).

## Verification

- `tsc -b`: 0 errors (was 93)
- `eslint .`: clean
- `npm run test:server`: 410/410 pass (was 403/404), including new stat-clamp regression tests
- `npm audit`: 0 vulnerabilities
- `vite build`: succeeds
- GUI smoke test in guest/offline mode (exercises the new Firebase null guards): home, Forge, Wiki, Codex, pricing modal all render; auth-gated pages show the login modal; no console errors beyond expected offline noise.

[smoke_test_pages_after_fixes.mp4](https://cursor.com/agents/bc-d6aff5f9-01ce-4065-acf0-ce4953a279f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsmoke_test_pages_after_fixes.mp4)

## Known issues not fixed here (need product decisions)

- Image-generation routes authenticate but don't enforce wallet/free-forge entitlements server-side (UI-only), so any account can burn Fal.ai quota via direct API calls.
- Trade acceptance runs client-side transactions; moving accept/decline + card transfer to a trusted server route would prevent status-desync griefing.
- Pending trades expose full offered-card payloads to all signed-in users via the Community Market read rule.
- Stripe checkout session creation is unauthenticated (rate-limited and price-allowlisted, but enables session spam).
- Referral credits can be farmed with multiple accounts; per-referrer caps would help.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6aff5f9-01ce-4065-acf0-ce4953a279f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6aff5f9-01ce-4065-acf0-ce4953a279f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

